### PR TITLE
Feature: Autonomous background monitoring via SleepTimer tool and Thread-Safe Async waking

### DIFF
--- a/nano_claude.py
+++ b/nano_claude.py
@@ -67,7 +67,7 @@ import textwrap
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, Union
-
+import threading
 # ── Optional rich for markdown rendering ──────────────────────────────────
 try:
     from rich.console import Console
@@ -1136,54 +1136,68 @@ def repl(config: dict, initial_prompt: str = None):
         print(clr("╰──────────────────────────────────────────────────╯", "dim"))
         print()
 
-    def run_query(user_input: str):
+    query_lock = threading.Lock()
+    
+    def run_query(user_input: str, is_background: bool = False):
         nonlocal verbose
-        verbose = config.get("verbose", False)
+        
+        with query_lock:
+            verbose = config.get("verbose", False)
+    
+            # Rebuild system prompt each turn (picks up cwd changes, etc.)
+            system_prompt = build_system_prompt()
+            
+            if is_background:
+                print(clr("\n\n[Background Event Triggered]", "yellow"))
+    
+            print(clr("\n╭─ Claude ", "dim") + clr("●", "green") + clr(" ─────────────────────────", "dim"))
+            print(clr("│ ", "dim"), end="", flush=True)
+    
+            thinking_started = False
+    
+            for event in run(user_input, state, config, system_prompt):
+                if isinstance(event, TextChunk):
+                    stream_text(event.text)
+    
+                elif isinstance(event, ThinkingChunk):
+                    if verbose:
+                        if not thinking_started:
+                            print(clr("\n  [thinking]", "dim"))
+                            thinking_started = True
+                        stream_thinking(event.text, verbose)
+    
+                elif isinstance(event, ToolStart):
+                    flush_response()
+                    print_tool_start(event.name, event.inputs, verbose)
+    
+                elif isinstance(event, PermissionRequest):
+                    event.granted = ask_permission_interactive(event.description, config)
+    
+                elif isinstance(event, ToolEnd):
+                    print_tool_end(event.name, event.result, verbose)
+                    # Print prefix for next text
+                    print(clr("│ ", "dim"), end="", flush=True)
+    
+                elif isinstance(event, TurnDone):
+                    if verbose:
+                        print(clr(
+                            f"\n  [tokens: +{event.input_tokens} in / "
+                            f"+{event.output_tokens} out]", "dim"
+                        ))
 
-        # Rebuild system prompt each turn (picks up cwd changes, etc.)
-        system_prompt = build_system_prompt()
+            flush_response()
+            print(clr("╰──────────────────────────────────────────────", "dim"))
+            print()
+            
+            # If this was a background task, we redraw the prompt for the user
+            if is_background:
+                print(clr("\n[claude-code-local] ❯ ", "yellow"), end="", flush=True)
 
-        print(clr("\n╭─ Claude ", "dim") + clr("●", "green") + clr(" ─────────────────────────", "dim"))
-        print(clr("│ ", "dim"), end="", flush=True)
-
-        thinking_started = False
-
-        for event in run(user_input, state, config, system_prompt):
-            if isinstance(event, TextChunk):
-                stream_text(event.text)
-
-            elif isinstance(event, ThinkingChunk):
-                if verbose:
-                    if not thinking_started:
-                        print(clr("\n  [thinking]", "dim"))
-                        thinking_started = True
-                    stream_thinking(event.text, verbose)
-
-            elif isinstance(event, ToolStart):
-                flush_response()
-                print_tool_start(event.name, event.inputs, verbose)
-
-            elif isinstance(event, PermissionRequest):
-                event.granted = ask_permission_interactive(event.description, config)
-
-            elif isinstance(event, ToolEnd):
-                print_tool_end(event.name, event.result, verbose)
-                # Print prefix for next text
-                print(clr("│ ", "dim"), end="", flush=True)
-
-            elif isinstance(event, TurnDone):
-                if verbose:
-                    print(clr(
-                        f"\n  [tokens: +{event.input_tokens} in / "
-                        f"+{event.output_tokens} out]", "dim"
-                    ))
-
-        flush_response()
-        print(clr("╰──────────────────────────────────────────────", "dim"))
-        print()
         # Drain any AskUserQuestion prompts raised during this turn
         from tools import drain_pending_questions
         drain_pending_questions()
+
+    config["_run_query_callback"] = lambda msg: run_query(msg, is_background=True)
 
     # ── Main loop ──
     if initial_prompt:

--- a/tools.py
+++ b/tools.py
@@ -293,6 +293,20 @@ TOOL_SCHEMAS = [
             "required": ["question"],
         },
     },
+    {
+        "name": "SleepTimer",
+        "description": (
+            "Schedule a silent background timer. When the timer finishes, it injects an automated prompt into the chat history: "
+            "'(System Automated Event): The timer has finished...' so you can seamlessly wake up and execute deferred monitoring tasks."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "seconds": {"type": "integer", "description": "Number of seconds to sleep before waking up."}
+            },
+            "required": ["seconds"],
+        },
+    },
 ]
 
 # ── Safe bash commands (never ask permission) ───────────────────────────────
@@ -833,6 +847,22 @@ def drain_pending_questions() -> bool:
     return True
 
 
+def _sleeptimer(seconds: int, config: dict) -> str:
+    import threading
+    cb = config.get("_run_query_callback")
+    if not cb:
+        return "Error: Internal callback missing, nano_claude did not provide _run_query_callback"
+        
+    def worker():
+        import time
+        time.sleep(seconds)
+        cb("(System Automated Event): The timer has finished. Please wake up, perform any pending monitoring checks and report to the user now.")
+        
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    return f"Timer successfully scheduled for {seconds} seconds. You can output your final thoughts and end your turn. You will be automatically awakened."
+
+
 # ── Dispatcher (backward-compatible wrapper) ──────────────────────────────
 
 def execute_tool(
@@ -979,6 +1009,13 @@ def _register_builtins() -> None:
             ),
             read_only=True,
             concurrent_safe=False,
+        ),
+        ToolDef(
+            name="SleepTimer",
+            schema=_schemas["SleepTimer"],
+            func=lambda p, c: _sleeptimer(p["seconds"], c),
+            read_only=False,
+            concurrent_safe=True,
         ),
     ]
     for td in _tool_defs:


### PR DESCRIPTION
### What this PR does
This PR upgrades the agent from a passive "chat-only" REPL interface into a truly autonomous Background Agent. It unlocks the ability for the AI to schedule tasks in the future, pause its own execution, and wake itself up to perform recurring analysis asynchronously without blocking the user's console!

### Changes made
1. **Added a new `SleepTimer` tool ([tools.py](cci:7://file:///c:/Users/Admin/Desktop/claude-code-local/tools.py:0:0-0:0))**: The AI can now call `SleepTimer(seconds=X)` to intentionally schedule a hidden wake-up alarm in the background.
2. **Introduced Thread-Safe Prompt Injection ([nano_claude.py](cci:7://file:///c:/Users/Admin/Desktop/claude-code-local/nano_claude.py:0:0-0:0))**: Implemented `query_lock` directly in the core runner. When the `SleepTimer` finishes, a daemon thread gracefully wakes up the main application and seamlessly pushes an internal system prompt [(System Automated Event)](cci:1://file:///c:/Users/Admin/Desktop/claude-code-local/nano_claude.py:102:0-102:46) to trigger the AI automatically without freezing `input()` or overlapping the UI.
3. **Updated System Prompt Guidelines ([context.py](cci:7://file:///c:/Users/Admin/Desktop/claude-code-local/context.py:0:0-0:0))**: The model's baseline instructions were enhanced so it stops wrongly claiming "it is just a chat interface that cannot monitor things". It now knows it has the explicit autonomy to execute recurring background checks natively.

### Proof of Concept (Working Output Example)
The REPL correctly handles background wake-ups, allowing the AI to analyze crypto market data automatically while the user does absolutely nothing!

```text
[localtest] ❯ set a timer for 60 seconds and give me the market results again when it ends.
╭─ Claude ● ─────────────────────────                                                                                      
│ ⚙ SleepTimer([60])                                                                                                        
│ ✓ → 1 lines (134 chars)                                                                                                  
│ I have set a timer for 60 seconds. I will run the market analysis again once it finishes.                                                                                                
╰──────────────────────────────────────────────                                                                                                                                                                                                                                                                                                                                  
[localtest] ❯                                                                                                                                                                                                                                         

[Background Event Triggered]                                                                                                                                                                                                                          
╭─ Claude ● ─────────────────────────                                                                                      
│ ⚙ Bash(python htmatrix_eth.py)                                                                                            
│ ✓ → 41 lines (820 chars)                                                                                                 
│ El análisis del mercado se ha ejecutado nuevamente tras la espera. Los resultados son muy similares a los anteriores, lo que sugiere una consistencia de soporte...                                                                                                                                              

Loving the project! <3