### PR TITLE
Feature: Proactive Background Agent Polling via `/proactive` command

### DIFF
--- a/nano_claude.py
+++ b/nano_claude.py
@@ -243,7 +243,7 @@ def _proactive_watcher_loop(config):
                 _last_interaction_time = now
                 cb = config.get("_run_query_callback")
                 if cb:
-                    cb(f"(System Automated Event) You have been inactive for {_proactive_interval} seconds. Check if you have any pending tasks to execute, monitor the market, or simply say 'No pending tasks'.")
+                    cb(f"(System Automated Event) You have been inactive for {_proactive_interval} seconds. Check if you have any pending tasks to execute or simply say 'No pending tasks'.")
         except Exception:
             pass
 


### PR DESCRIPTION
### What this PR does
Introduces the `/proactive [duration]` command, morphing Nano Claude from a reactive conversational CLI into an autonomous "Sentinel Agent" capable of infinite background tracking.

By typing `/proactive 5m` (default: 5 minutes), the CLI activates a background Daemon Thread that watches for user inactivity. If the console remains silent for the specified duration, the thread seamlessly wakes the agent up, prompting it to review pending tasks, evaluate market scripts, and autonomously alert the user if conditions are met. 

### Key Capabilities & Safeties
- **True Inactivity Timer:** The internal clock (`_last_interaction_time`) rests at the exact end of *every* agent or user message. The background polling will NEVER interrupt an active coding or chat session.
- **Toggleable Design:** Defaults to `OFF` unless explicitly called, preserving Nano Claude’s swift baseline. Users can toggle polling with brief inputs like `/proactive 30s` or `/proactive 1h`.

### Use Case Example (Continuous Monitoring)
This allows developers to deploy algorithmic trading bots or monitoring scripts and rely on Nano Claude to repetitively execute shell scripts in the background and analyze changing states continuously:

```text
[localtest] ❯ /proactive 5m
Proactive background polling: ON (Triggering every 300s of inactivity)

[localtest] ❯ bien, sigue analizando cuando sigas recibiendo los wake calls

╭─ Claude ● ─────────────────────────
│ Entendido. Continuaré monitoreando y analizando cada vez que reciba una `wake call`.


[Background Event Triggered]
╭─ Claude ● ─────────────────────────
│ ⚙ Bash(python htmatrix_eth.py) 
│ ✓ → 41 lines (820 chars) 
│ **Estado del mercado actualizado:** El soporte anterior se rompió y entramos en un nuevo canal de volatilidad. Te sugiero ajustar el stop loss.
╰───────────────────────────────────────── 

