### PR TITLE
fix: ollama remote base URL override and graceful readline error hand…

### DIFF
--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -3226,10 +3226,15 @@ def setup_readline(history_file: Path):
         return
     try:
         readline.read_history_file(str(history_file))
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError, OSError):
         pass
     readline.set_history_length(1000)
-    atexit.register(readline.write_history_file, str(history_file))
+    def _save_history():
+        try:
+            readline.write_history_file(str(history_file))
+        except Exception:
+            pass
+    atexit.register(_save_history)
 
     # Allow "/" to be part of a completion token so "/model" is one word
     delims = readline.get_completer_delims().replace("/", "")

--- a/providers.py
+++ b/providers.py
@@ -649,7 +649,12 @@ def stream(
     if prov["type"] == "anthropic":
         yield from stream_anthropic(api_key, model_name, system, messages, tool_schemas, config)
     elif prov["type"] == "ollama":
-        base_url = prov.get("base_url", "http://localhost:11434")
+        import os as _os
+        base_url = (
+            _os.environ.get("OLLAMA_BASE_URL")
+            or config.get("ollama_base_url")
+            or prov.get("base_url", "http://localhost:11434")
+        )
         yield from stream_ollama(base_url, model_name, system, messages, tool_schemas, config)
     else:
         import os as _os


### PR DESCRIPTION
…ling

Two fixes for running cheetahclaws in containerised/remote environments:

1. providers.py: Allow OLLAMA_BASE_URL environment variable (and ollama_base_url config key) to override the hardcoded localhost:11434 default for the ollama provider. This enables using a remote Ollama instance without switching to the custom provider.

2. cheetahclaws.py: Broaden exception handling in setup_readline to catch PermissionError and OSError on read_history_file, and wrap the atexit write_history_file callback in a try/except so errors on shutdown are silently swallowed rather than surfaced as noisy tracebacks. This affects bind-mounted or read-only home directories (e.g. Docker).