### PR TITLE
Add retry mechanism and fix token estimator — never crash on API errors

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Generator
@@ -10,7 +11,7 @@ from tool_registry import get_tool_schemas
 from tools import execute_tool
 import tools as _tools_init  # ensure built-in tools are registered on import
 from providers import stream, AssistantTurn, TextChunk, ThinkingChunk, detect_provider
-from compaction import maybe_compact
+from compaction import maybe_compact, estimate_tokens, get_context_limit, compact_messages
 
 # ── Re-export event types (used by cheetahclaws.py) ────────────────────────
 __all__ = [
@@ -90,18 +91,50 @@ def run(
         # Compact context if approaching window limit
         maybe_compact(state, config)
 
-        # Stream from provider (auto-detected from model name)
-        for event in stream(
-            model=config["model"],
-            system=system_prompt,
-            messages=state.messages,
-            tool_schemas=get_tool_schemas(),
-            config=config,
-        ):
-            if isinstance(event, (TextChunk, ThinkingChunk)):
-                yield event
-            elif isinstance(event, AssistantTurn):
-                assistant_turn = event
+        # Stream from provider — retry on ANY error (never crash the session)
+        max_retries = 3
+        for attempt in range(max_retries + 1):
+            try:
+                for event in stream(
+                    model=config["model"],
+                    system=system_prompt,
+                    messages=state.messages,
+                    tool_schemas=get_tool_schemas(),
+                    config=config,
+                ):
+                    if isinstance(event, (TextChunk, ThinkingChunk)):
+                        yield event
+                    elif isinstance(event, AssistantTurn):
+                        assistant_turn = event
+                break  # success — exit retry loop
+            except Exception as e:
+                if attempt >= max_retries:
+                    yield TextChunk(f"\n[Failed after {max_retries} retries — {_truncate_err(str(e))}. Please retry manually.]\n")
+                    break  # give up gracefully instead of crashing
+
+                err_str = str(e).lower()
+                err_type = type(e).__name__
+
+                is_context_too_long = any(s in err_str for s in [
+                    "context_length", "context window", "too many tokens",
+                    "input is too long", "prompt is too long",
+                    "request too large", "token limit",
+                ])
+                is_overloaded = "overloaded" in err_str or "overloaded_error" in err_type
+                is_rate_limit = "rate_limit" in err_str or e.__class__.__name__ == "RateLimitError"
+
+                if is_context_too_long:
+                    _force_compact(state, config)
+                    yield TextChunk(f"\n[Context too long — compacted and retrying (attempt {attempt+1}/{max_retries})]\n")
+                    continue
+
+                # All other errors: backoff + retry (overloaded gets longer backoff)
+                if is_overloaded or is_rate_limit:
+                    backoff = min(30, 2 ** (attempt + 2))  # 4s, 8s, 16s
+                else:
+                    backoff = 2 ** (attempt + 1)  # 2s, 4s, 8s
+                yield TextChunk(f"\n[Retry {attempt+1}/{max_retries} after {backoff}s — {err_type}: {_truncate_err(str(e))}]\n")
+                time.sleep(backoff)
 
         if assistant_turn is None:
             break
@@ -211,3 +244,24 @@ def _permission_desc(tc: dict) -> str:
     if name == "Write":  return f"Write to: {inp.get('file_path', '')}"
     if name == "Edit":   return f"Edit: {inp.get('file_path', '')}"
     return f"{name}({list(inp.values())[:1]})"
+
+
+def _force_compact(state: AgentState, config: dict) -> bool:
+    """Force compaction regardless of threshold. Used when API rejects for context too long."""
+    limit = get_context_limit(config.get("model", ""))
+    before = estimate_tokens(state.messages)
+    if before <= 0:
+        return False
+    from compaction import snip_old_tool_results
+    snip_old_tool_results(state.messages, max_chars=1000, preserve_last_n_turns=3)
+    if estimate_tokens(state.messages) < limit * 0.9:
+        return True
+    state.messages = compact_messages(state.messages, config)
+    after = estimate_tokens(state.messages)
+    return after < before
+
+
+def _truncate_err(s: str, max_len: int = 120) -> str:
+    if len(s) <= max_len:
+        return s
+    return s[:max_len - 3] + "..."

--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -118,6 +118,11 @@ def ok(msg: str):     print(clr(msg, "green"))
 def warn(msg: str):   print(clr(f"Warning: {msg}", "yellow"))
 def err(msg: str):    print(clr(f"Error: {msg}", "red"), file=sys.stderr)
 
+def _truncate_err_global(s: str, max_len: int = 200) -> str:
+    if len(s) <= max_len:
+        return s
+    return s[:max_len - 3] + "..."
+
 
 # ── Load feature modules from modular/ ecosystem ──────────────────────────────
 # Commands from modular/ are merged into COMMANDS after the dict is built.
@@ -3513,21 +3518,38 @@ def repl(config: dict, initial_prompt: str = None):
                 raise  # propagate to REPL handler which calls _track_ctrl_c
             except Exception as e:
                 _stop_tool_spinner()
+                flush_response()
                 import urllib.error
                 # Catch 404 Not Found (Ollama model missing)
                 if isinstance(e, urllib.error.HTTPError) and e.code == 404:
                     from providers import detect_provider
                     if detect_provider(config["model"]) == "ollama":
-                        flush_response()
                         err(f"Ollama model '{config['model']}' not found.")
                         if _interactive_ollama_picker(config):
-                            # Remove the user message added by run() before retrying
                             if state.messages and state.messages[-1]["role"] == "user":
                                 state.messages.pop()
                             return run_query(user_input, is_background)
-                        # User cancelled picker — abort gracefully without crashing
                         return
-                raise e
+                # Context too long — force compact and retry
+                err_str = str(e).lower()
+                is_context_err = any(s in err_str for s in [
+                    "context_length", "context window", "too many tokens",
+                    "input is too long", "prompt is too long", "token limit",
+                ])
+                if is_context_err:
+                    warn("Context too long — forcing compaction and retrying...")
+                    from compaction import estimate_tokens, get_context_limit
+                    from agent import _force_compact
+                    _force_compact(state, config)
+                    after = estimate_tokens(state.messages)
+                    limit = get_context_limit(config.get("model", ""))
+                    if after < limit * 0.9:
+                        return run_query(user_input, is_background)
+                    err(f"Context still too large after compaction ({after} / {limit} tokens). Try /compact or start a new session.")
+                    return
+                # Any other uncaught error — never crash, just report and let user retry
+                err(f"Error: {type(e).__name__}: {_truncate_err_global(str(e))}")
+                warn("Your conversation is intact. You can retry or type a new message.")
 
             _stop_tool_spinner()
             flush_response()  # stop Live, commit any remaining text

--- a/compaction.py
+++ b/compaction.py
@@ -7,7 +7,14 @@ import providers
 # ── Token estimation ──────────────────────────────────────────────────────
 
 def estimate_tokens(messages: list) -> int:
-    """Estimate token count by summing content lengths / 3.5.
+    """Estimate token count. Uses chars/2.8 (conservative for code-heavy content).
+
+    The old chars/3.5 divisor underestimated real token counts for code-heavy
+    conversations because: (1) code tokens are ~2.5-3 chars each, not 3.5,
+    (2) tool schemas, JSON keys, and special chars take more tokens than plain
+    text, (3) per-message framing overhead (~4 tokens/msg) is not counted.
+    This caused compaction to skip when it should have triggered, leading to
+    context overflow crashes.
 
     Args:
         messages: list of message dicts with "content" field (str or list of dicts)
@@ -15,24 +22,27 @@ def estimate_tokens(messages: list) -> int:
         approximate token count, int
     """
     total_chars = 0
+    msg_count = 0
     for m in messages:
+        msg_count += 1
         content = m.get("content", "")
         if isinstance(content, str):
             total_chars += len(content)
         elif isinstance(content, list):
             for block in content:
                 if isinstance(block, dict):
-                    # Sum all string values in the block
                     for v in block.values():
                         if isinstance(v, str):
                             total_chars += len(v)
-        # Also count tool_calls if present
         for tc in m.get("tool_calls", []):
             if isinstance(tc, dict):
                 for v in tc.values():
                     if isinstance(v, str):
                         total_chars += len(v)
-    return int(total_chars / 3.5)
+    # chars/2.8 for content + 4 tokens/msg framing overhead + 10% buffer
+    content_tokens = int(total_chars / 2.8)
+    framing_tokens = msg_count * 4
+    return int((content_tokens + framing_tokens) * 1.1)
 
 
 def get_context_limit(model: str) -> int:


### PR DESCRIPTION
Three changes:

1. compaction.py: Fix token estimator (chars/3.5 → chars/2.8 + framing + buffer)
   - Old divisor underestimated real token counts for code-heavy content
   - Added per-message framing overhead (+4 tokens/msg) and 10% safety buffer
   - This caused compaction to skip when it should trigger, leading to context overflow crashes

2. agent.py: Add retry with exponential backoff on ALL errors
   - 3 retries with backoff (2s, 4s, 8s; overloaded gets 4s, 8s, 16s)
   - Context-too-long errors: force compact and retry immediately
   - After exhausting retries: graceful message instead of crashing
   - No more bare raise — session never dies from an API error

3. cheetahclaws.py: Safety net in run_query() for uncaught errors
   - Context-too-long: force compact + retry
   - Any other error: show message, keep session alive
   - Removed the final 'raise e' that crashed the REPL