### PR TITLE
Fix:Prevent TypeError on /config by filtering out non-serializable Th…

### DIFF
--- a/commands/config_cmd.py
+++ b/commands/config_cmd.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 
 from ui.render import clr, info, ok, warn, err
 
@@ -83,7 +84,8 @@ def _interactive_ollama_picker(config: dict) -> bool:
 def cmd_config(args: str, _state, config) -> bool:
     from config import save_config
     if not args:
-        display = {k: v for k, v in config.items() if k != "api_key"}
+        display = {k: v for k, v in config.items() if k != "api_key" and k != "_proactive_thread" and not isinstance(v,
+ type(threading.Thread))}
         print(json.dumps(display, indent=2))
     elif "=" in args:
         key, _, val = args.partition("=")


### PR DESCRIPTION
## Context
Current `main` is broken (https://github.com/SafeRL-Lab/cheetahclaws/issues/36). 

## What this PR does
Prevent TypeError crash on /config command by filtering out non-serializable Thread objects.

## Why this branch is based on an older commit (commit: 186df27b02a602ac5a129cd19443b0821fd560ce)
This fix was developed on top of the last known working state.