### PR TITLE
feat: add typing-time autosuggest to slash commands

### DIFF
--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -131,7 +131,9 @@ from ui.render import (
 )
 
 # ── Input layer (prompt_toolkit with readline fallback) ──────────────────
-from ui.input import read_line as _pt_read_line, HAS_PROMPT_TOOLKIT
+import ui.input as _ui_input
+_pt_read_line = _ui_input.read_line
+HAS_PROMPT_TOOLKIT = _ui_input.HAS_PROMPT_TOOLKIT
 
 # ── Bridge commands ────────────────────────────────────────────────────────
 import bridges.telegram as _btg
@@ -492,6 +494,10 @@ def setup_readline(history_file: Path):
             pass
     atexit.register(_save_history)
 
+    # Allow "/" to be part of a completion token so "/model" is one word
+    delims = readline.get_completer_delims().replace("/", "")
+    readline.set_completer_delims(delims)
+
     def completer(text: str, state: int):
         line = readline.get_line_buffer()
 
@@ -519,11 +525,12 @@ def setup_readline(history_file: Path):
         if is_cmd:
             col_w = max(len(m) for m in matches) + 2
             for m in sorted(matches):
-                desc = _CMD_META.get(m, ("", []))[0]
-                subs = _CMD_META.get(m, ("", []))[1]
+                cmd = m[1:]
+                desc = _CMD_META.get(cmd, ("", []))[0]
+                subs = _CMD_META.get(cmd, ("", []))[1]
                 sub_hint = ("  [" + ", ".join(subs[:4])
                             + ("…" if len(subs) > 4 else "") + "]") if subs else ""
-                sys.stdout.write(f"  \033[36m/{m:<{col_w}}\033[0m  {desc}{sub_hint}\n")
+                sys.stdout.write(f"  \033[36m{m:<{col_w}}\033[0m  {desc}{sub_hint}\n")
         else:
             for m in sorted(matches):
                 sys.stdout.write(f"  {m}\n")
@@ -543,8 +550,18 @@ def repl(config: dict, initial_prompt: str = None):
     from context import build_system_prompt
     from agent import AgentState, run, TextChunk, ThinkingChunk, ToolStart, ToolEnd, TurnDone, PermissionRequest
 
-    if not HAS_PROMPT_TOOLKIT:
+    if HAS_PROMPT_TOOLKIT:
+        # Inject live providers so ui.input's completer enumerates the same
+        # command set the dispatcher accepts (includes plugin/modular adds).
+        _ui_input.setup(lambda: COMMANDS, lambda: _CMD_META)
+    else:
         setup_readline(HISTORY_FILE)
+
+    # prompt_toolkit's FileHistory uses an incompatible format to readline's
+    # history file, so give it a sibling path. Both persist across sessions;
+    # toggling CHEETAH_PT_INPUT only switches which file is active.
+    PT_HISTORY_FILE = HISTORY_FILE.with_name("input_history_pt.txt")
+
     state = AgentState()
     verbose = config.get("verbose", False)
 
@@ -968,17 +985,27 @@ def repl(config: dict, initial_prompt: str = None):
 
         # ── Phase 1a: prompt_toolkit (TTY + library available + not opted out) ─
         # Handles bracketed paste natively, so phase-2/3 are skipped on success.
+        # Preserves the "(pasted N lines)" notification for parity with the
+        # readline-based paste handling in phase 2/3.
         if (
             HAS_PROMPT_TOOLKIT
             and sys.stdin.isatty()
             and os.environ.get("CHEETAH_PT_INPUT", "1") != "0"
         ):
             try:
-                return _pt_read_line(prompt, HISTORY_FILE)
+                result = _pt_read_line(prompt, PT_HISTORY_FILE)
+                if "\n" in result:
+                    n = result.count("\n") + 1
+                    info(f"  (pasted {n} line{'s' if n > 1 else ''})")
+                return result
             except (EOFError, KeyboardInterrupt):
                 raise
             except Exception as _pt_err:
-                warn(f"prompt_toolkit failed ({_pt_err}); falling back to readline")
+                warn(
+                    f"prompt_toolkit failed ({type(_pt_err).__name__}: {_pt_err}); "
+                    "falling back to readline"
+                )
+                _ui_input.reset_session()
                 # fall through to phase 1b
 
         # ── Phase 1b: get first line via readline (history, line-edit intact) ──

--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -130,6 +130,9 @@ from ui.render import (
     _RICH, console,
 )
 
+# ── Input layer (prompt_toolkit with readline fallback) ──────────────────
+from ui.input import read_line as _pt_read_line, HAS_PROMPT_TOOLKIT
+
 # ── Bridge commands ────────────────────────────────────────────────────────
 import bridges.telegram as _btg
 import bridges.wechat   as _bwx
@@ -489,10 +492,6 @@ def setup_readline(history_file: Path):
             pass
     atexit.register(_save_history)
 
-    # Allow "/" to be part of a completion token so "/model" is one word
-    delims = readline.get_completer_delims().replace("/", "")
-    readline.set_completer_delims(delims)
-
     def completer(text: str, state: int):
         line = readline.get_line_buffer()
 
@@ -520,12 +519,11 @@ def setup_readline(history_file: Path):
         if is_cmd:
             col_w = max(len(m) for m in matches) + 2
             for m in sorted(matches):
-                cmd = m[1:]
-                desc = _CMD_META.get(cmd, ("", []))[0]
-                subs = _CMD_META.get(cmd, ("", []))[1]
+                desc = _CMD_META.get(m, ("", []))[0]
+                subs = _CMD_META.get(m, ("", []))[1]
                 sub_hint = ("  [" + ", ".join(subs[:4])
                             + ("…" if len(subs) > 4 else "") + "]") if subs else ""
-                sys.stdout.write(f"  \033[36m{m:<{col_w}}\033[0m  {desc}{sub_hint}\n")
+                sys.stdout.write(f"  \033[36m/{m:<{col_w}}\033[0m  {desc}{sub_hint}\n")
         else:
             for m in sorted(matches):
                 sys.stdout.write(f"  {m}\n")
@@ -545,7 +543,8 @@ def repl(config: dict, initial_prompt: str = None):
     from context import build_system_prompt
     from agent import AgentState, run, TextChunk, ThinkingChunk, ToolStart, ToolEnd, TurnDone, PermissionRequest
 
-    setup_readline(HISTORY_FILE)
+    if not HAS_PROMPT_TOOLKIT:
+        setup_readline(HISTORY_FILE)
     state = AgentState()
     verbose = config.get("verbose", False)
 
@@ -967,7 +966,22 @@ def repl(config: dict, initial_prompt: str = None):
         global _rl_current_prompt
         import select as _sel
 
-        # ── Phase 1: get first line via readline (history, line-edit intact) ──
+        # ── Phase 1a: prompt_toolkit (TTY + library available + not opted out) ─
+        # Handles bracketed paste natively, so phase-2/3 are skipped on success.
+        if (
+            HAS_PROMPT_TOOLKIT
+            and sys.stdin.isatty()
+            and os.environ.get("CHEETAH_PT_INPUT", "1") != "0"
+        ):
+            try:
+                return _pt_read_line(prompt, HISTORY_FILE)
+            except (EOFError, KeyboardInterrupt):
+                raise
+            except Exception as _pt_err:
+                warn(f"prompt_toolkit failed ({_pt_err}); falling back to readline")
+                # fall through to phase 1b
+
+        # ── Phase 1b: get first line via readline (history, line-edit intact) ──
         # Wrap ANSI codes so readline counts them as zero-width (#29/#31).
         rl_prompt = re.sub(r'(\x1b\[[0-9;]*m)', r'\001\1\002', prompt)
         _rl_current_prompt = prompt   # for display_matches to redisplay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "pyte>=0.8.0",
+    "prompt_toolkit>=3.0.43",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "pyte>=0.8.0",
-    "prompt_toolkit>=3.0.43",
 ]
 
 [project.optional-dependencies]
-voice  = ["sounddevice"]
-vision = ["Pillow"]
+voice       = ["sounddevice"]
+vision      = ["Pillow"]
+autosuggest = ["prompt_toolkit>=3.0.43"]
 
 [project.scripts]
 cheetahclaws = "cheetahclaws:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,10 @@ anthropic>=0.40.0
 openai>=1.30.0
 httpx>=0.27.0
 rich>=13.0.0
-pyte>=0.8.0
+pyte>=0.8.0            # terminal emulator for !claude / !python bridge rendering
+
+# Optional — install to enable typing-time slash-command autosuggest.
+# Also available as an extra: `pip install cheetahclaws[autosuggest]`.
 prompt_toolkit>=3.0.43
 
 # ── Optional dependencies ────────────────────────────────────────────────

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ openai>=1.30.0
 httpx>=0.27.0
 rich>=13.0.0
 pyte>=0.8.0
+prompt_toolkit>=3.0.43
 
 # ── Optional dependencies ────────────────────────────────────────────────
 # Voice input:  pip install cheetahclaws[voice]

--- a/tests/e2e_slash_prompt.py
+++ b/tests/e2e_slash_prompt.py
@@ -1,0 +1,136 @@
+"""PTY smoke test for the prompt_toolkit input layer.
+
+Exercises `ui/input.read_line` end-to-end through a pseudo-terminal without
+spinning up the full CheetahClaws REPL. Gated on prompt_toolkit availability.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import sys
+import time
+
+import pytest
+
+from ui.input import HAS_PROMPT_TOOLKIT
+
+if not HAS_PROMPT_TOOLKIT:
+    pytest.skip("prompt_toolkit not installed", allow_module_level=True)
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+_CHILD_SCRIPT = r"""
+import sys
+sys.path.insert(0, {repo_root!r})
+import ui.input as _ui
+
+_COMMANDS = {{"help": True, "clear": True, "checkpoint": True, "cwd": True,
+              "compact": True, "config": True, "cost": True, "copy": True,
+              "context": True, "cloudsave": True}}
+_META = {{
+    "help":       ("Show help", []),
+    "clear":      ("Clear", []),
+    "checkpoint": ("Checkpoints", ["clear"]),
+    "cwd":        ("Working directory", []),
+    "compact":    ("Compact", []),
+    "config":     ("Config", []),
+    "cost":       ("Cost", []),
+    "copy":       ("Copy", []),
+    "context":    ("Context", []),
+    "cloudsave":  ("Cloud save", ["setup", "auto", "list"]),
+}}
+_ui._commands_provider = lambda: _COMMANDS
+_ui._meta_provider = lambda: _META
+
+result = _ui.read_line("[test] > ")
+sys.stdout.write("RESULT=" + repr(result) + chr(10))
+sys.stdout.flush()
+"""
+
+
+def _run_child(keystrokes: list[tuple[float, bytes]], timeout: float = 4.0) -> bytes:
+    """Spawn the child under a PTY and play a sequence of (delay, bytes) writes.
+
+    Reads until 'RESULT=' lands on stdout or the timeout expires.
+    """
+    script = _CHILD_SCRIPT.format(repo_root=_REPO_ROOT)
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execv(sys.executable, [sys.executable, "-c", script])
+
+    collected = bytearray()
+    start = time.monotonic()
+    write_queue = list(keystrokes)
+
+    try:
+        # Give prompt_toolkit time to render its initial screen.
+        time.sleep(0.3)
+
+        while time.monotonic() - start < timeout:
+            # Send the next keystroke if its scheduled delay has elapsed.
+            if write_queue:
+                delay, payload = write_queue[0]
+                if time.monotonic() - start >= delay:
+                    try:
+                        os.write(fd, payload)
+                    except OSError:
+                        pass
+                    write_queue.pop(0)
+
+            rlist, _, _ = select.select([fd], [], [], 0.1)
+            if fd in rlist:
+                try:
+                    chunk = os.read(fd, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                collected.extend(chunk)
+                if b"RESULT=" in bytes(collected):
+                    break
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+
+    return bytes(collected)
+
+
+def test_enter_dispatches_typed_text():
+    """Typing a command and pressing Enter returns that command verbatim."""
+    output = _run_child([(0.3, b"/help"), (0.6, b"\r")])
+    assert b"RESULT='/help'" in output, output[-500:]
+
+
+def test_typing_slash_c_renders_menu_with_matches():
+    """Typing `/c` produces completion output containing at least one /c-prefixed command."""
+    output = _run_child([(0.3, b"/c"), (0.8, b"\r")])
+    # Some /c-prefixed command name must appear in the rendered buffer.
+    assert any(
+        fragment in output for fragment in (
+            b"/checkpoint", b"/clear", b"/cwd", b"/compact",
+            b"/config", b"/copy", b"/cost", b"/context", b"/cloudsave",
+        )
+    ), output[-500:]
+
+
+def test_arrow_down_then_enter_picks_first_menu_entry():
+    """Down-arrow selects the first completion, Enter accepts it.
+
+    The first /c-prefixed completion in sorted order is /checkpoint.
+    """
+    output = _run_child([
+        (0.3, b"/c"),
+        (0.8, b"\x1b[B"),   # down arrow
+        (1.1, b"\r"),
+    ])
+    assert b"RESULT='/checkpoint'" in output, output[-500:]

--- a/tests/test_input_completer.py
+++ b/tests/test_input_completer.py
@@ -1,0 +1,134 @@
+"""Unit tests for the slash-command completer in ui/input.py.
+
+Covers the two-level completion, the COMMANDS+meta symmetry fix, and the
+regression guard for the `/c/cwd` glue bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ui.input import HAS_PROMPT_TOOLKIT, SlashCompleter
+
+if not HAS_PROMPT_TOOLKIT:
+    pytest.skip("prompt_toolkit not installed", allow_module_level=True)
+
+from prompt_toolkit.document import Document
+
+
+META = {
+    "help":       ("Show help", []),
+    "clear":      ("Clear conversation history", []),
+    "checkpoint": ("List / restore checkpoints", ["clear"]),
+    "compact":    ("Compact conversation history", []),
+    "config":     ("Show / set config key=value", []),
+    "context":    ("Show token-context usage", []),
+    "copy":       ("Copy last response to clipboard", []),
+    "cost":       ("Show cost estimate", []),
+    "cwd":        ("Show / change working directory", []),
+    "cloudsave":  ("Cloud-sync sessions to GitHub Gist",
+                   ["setup", "auto", "list", "load", "push"]),
+    "mcp":        ("Manage MCP servers", ["reload", "add", "remove"]),
+    "plugin":     ("Manage plugins",
+                   ["install", "uninstall", "enable", "disable"]),
+}
+
+COMMANDS = {name: (lambda *a, **k: True) for name in META}
+
+
+def _completions(completer, text: str):
+    doc = Document(text, cursor_position=len(text))
+    return list(completer.get_completions(doc, complete_event=None))
+
+
+def _make_completer(commands=None, meta=None):
+    commands = commands if commands is not None else dict(COMMANDS)
+    meta = meta if meta is not None else dict(META)
+    return SlashCompleter(lambda: commands, lambda: meta)
+
+
+def test_level1_c_prefix_includes_cwd_and_siblings():
+    completer = _make_completer()
+    texts = [c.text for c in _completions(completer, "/c")]
+    assert "/cwd" in texts
+    assert "/clear" in texts
+    assert "/checkpoint" in texts
+    assert "/compact" in texts
+    assert "/config" in texts
+    assert "/context" in texts
+    assert "/copy" in texts
+    assert "/cost" in texts
+    assert "/cloudsave" in texts
+    # Irrelevant commands should not leak in
+    assert "/help" not in texts
+
+
+def test_level1_empty_slash_yields_all_commands():
+    completer = _make_completer()
+    texts = [c.text for c in _completions(completer, "/")]
+    assert len(texts) == len(META)
+    assert set(texts) == {"/" + name for name in META}
+
+
+def test_level1_display_meta_includes_description_and_subhint():
+    completer = _make_completer()
+    results = _completions(completer, "/p")
+    (plugin,) = [c for c in results if c.text == "/plugin"]
+    assert "Manage plugins" in plugin.display_meta_text
+    assert "install" in plugin.display_meta_text
+
+
+def test_level2_subcommand_completion():
+    completer = _make_completer()
+    completions = _completions(completer, "/mcp r")
+    texts = [c.text for c in completions]
+    assert "reload" in texts
+    assert "remove" in texts
+    assert "add" not in texts  # does not start with 'r'
+
+
+def test_level2_no_subcommands_for_command_without_any():
+    completer = _make_completer()
+    completions = _completions(completer, "/clear x")
+    assert completions == []
+
+
+def test_non_slash_input_yields_nothing():
+    completer = _make_completer()
+    assert _completions(completer, "hello") == []
+    assert _completions(completer, "") == []
+    assert _completions(completer, " /help") == []  # leading space
+
+
+def test_slash_c_cwd_glue_yields_nothing():
+    """Regression guard: `/c/cwd` must not match any real command."""
+    completer = _make_completer()
+    completions = _completions(completer, "/c/cwd")
+    assert completions == []
+
+
+def test_live_command_registration_visible_without_restart():
+    """Commands added to the live dict (e.g. via /plugin install) appear."""
+    live_commands = dict(COMMANDS)
+    live_meta = dict(META)
+    completer = SlashCompleter(lambda: live_commands, lambda: live_meta)
+
+    # Warm cache with a query.
+    assert [c.text for c in _completions(completer, "/f")] == []
+
+    # Register a new command at runtime.
+    live_commands["fakecmd"] = lambda *a, **k: True
+    live_meta["fakecmd"] = ("Fake test command", [])
+
+    texts = [c.text for c in _completions(completer, "/f")]
+    assert "/fakecmd" in texts
+
+
+def test_symmetry_commands_only_also_visible():
+    """Commands present in COMMANDS but missing from _CMD_META still complete."""
+    cmds = dict(COMMANDS)
+    cmds["orphan"] = lambda *a, **k: True
+    completer = SlashCompleter(lambda: cmds, lambda: dict(META))
+
+    texts = [c.text for c in _completions(completer, "/or")]
+    assert "/orphan" in texts

--- a/tests/test_input_completer.py
+++ b/tests/test_input_completer.py
@@ -132,3 +132,31 @@ def test_symmetry_commands_only_also_visible():
 
     texts = [c.text for c in _completions(completer, "/or")]
     assert "/orphan" in texts
+
+
+def test_setup_registers_module_level_providers():
+    """Verify ui.input.setup() injects providers without requiring ctor args."""
+    import ui.input as ui_input
+
+    cmds = {"alpha": True, "beta": True}
+    meta = {"alpha": ("A", []), "beta": ("B", [])}
+    ui_input.setup(lambda: cmds, lambda: meta)
+    try:
+        completer = SlashCompleter()  # no ctor args — reads module-level
+        texts = [c.text for c in _completions(completer, "/a")]
+        assert "/alpha" in texts
+        assert "/beta" not in texts
+    finally:
+        ui_input.setup(lambda: {}, lambda: {})
+
+
+def test_module_does_not_import_cheetahclaws():
+    """Regression guard for the circular-import concern from review."""
+    import sys
+    import ui.input as ui_input
+    # Reload ui.input in a clean state and confirm cheetahclaws is not pulled in.
+    # (Running this in the test session where cheetahclaws may already be loaded
+    # is acceptable — the assertion is about ui.input's own import graph.)
+    src = open(ui_input.__file__).read()
+    assert "import cheetahclaws" not in src
+    assert "from cheetahclaws" not in src

--- a/tools/fs.py
+++ b/tools/fs.py
@@ -5,6 +5,17 @@ import difflib
 from pathlib import Path
 
 
+def _read_preserving_newlines(p: Path) -> str:
+    """Read a text file without newline translation.
+
+    Path.read_text gained a `newline=` parameter only in Python 3.14; the
+    project supports 3.10+, so we use open() which has accepted `newline=`
+    since the pathlib API was introduced.
+    """
+    with p.open(encoding="utf-8", errors="replace", newline="") as f:
+        return f.read()
+
+
 # ── Diff helpers ──────────────────────────────────────────────────────────
 
 def generate_unified_diff(old: str, new: str, filename: str,
@@ -37,8 +48,7 @@ def _read(file_path: str, limit: int = None, offset: int = None) -> str:
     if p.is_dir():
         return f"Error: {file_path} is a directory"
     try:
-        lines = p.read_text(encoding="utf-8", errors="replace",
-                            newline="").splitlines(keepends=True)
+        lines = _read_preserving_newlines(p).splitlines(keepends=True)
         start = offset or 0
         chunk = lines[start:start + limit] if limit else lines[start:]
         if not chunk:
@@ -54,8 +64,7 @@ def _write(file_path: str, content: str) -> str:
     p = Path(file_path)
     try:
         is_new      = not p.exists()
-        old_content = ("" if is_new
-                       else p.read_text(encoding="utf-8", errors="replace", newline=""))
+        old_content = "" if is_new else _read_preserving_newlines(p)
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8", newline="")
         if is_new:
@@ -77,7 +86,7 @@ def _edit(file_path: str, old_string: str, new_string: str,
     if not p.exists():
         return f"Error: file not found: {file_path}"
     try:
-        content = p.read_text(encoding="utf-8", errors="replace", newline="")
+        content = _read_preserving_newlines(p)
 
         crlf_count = content.count("\r\n")
         lf_count   = content.count("\n")

--- a/ui/input.py
+++ b/ui/input.py
@@ -1,8 +1,11 @@
 """prompt_toolkit-based REPL input with typing-time slash-command autosuggest.
 
-Falls back silently when prompt_toolkit is not installed (HAS_PROMPT_TOOLKIT is
-then False), letting the existing readline path in cheetahclaws._read_input
-handle input.
+Optional dependency: when prompt_toolkit is not installed, HAS_PROMPT_TOOLKIT
+is False and callers should fall through to readline-based input.
+
+Dependency-injected: callers register command/meta providers via setup()
+before calling read_line(). This module never imports cheetahclaws — keeping
+the dependency one-way and eliminating any circular-import risk.
 """
 
 from __future__ import annotations
@@ -23,106 +26,138 @@ except ImportError:
     HAS_PROMPT_TOOLKIT = False
 
 
-class SlashCompleter(Completer if HAS_PROMPT_TOOLKIT else object):
-    """Two-level completer for slash commands.
+# ── Injected providers ───────────────────────────────────────────────────────
+# Callers (cheetahclaws.repl) must call setup() before read_line().
+_commands_provider: Optional[Callable[[], dict]] = None
+_meta_provider: Optional[Callable[[], dict]] = None
 
-    Level 1: /partial  (no space) → command names.
-    Level 2: /cmd partial          → subcommands listed in _CMD_META.
 
-    Sources:
-      - Live COMMANDS dict from cheetahclaws (includes modular/plugin additions).
-      - _CMD_META for description + subcommand hints.
+def setup(
+    commands_provider: Callable[[], dict],
+    meta_provider: Callable[[], dict],
+) -> None:
+    """Register providers for the live command registry and metadata.
+
+    `commands_provider` returns the dispatcher's COMMANDS dict.
+    `meta_provider` returns the _CMD_META dict (descriptions + subcommands).
     """
-
-    def __init__(
-        self,
-        commands_provider: Callable[[], dict],
-        meta_provider: Callable[[], dict],
-    ):
-        self._commands_provider = commands_provider
-        self._meta_provider = meta_provider
-        self._cache_key: Optional[tuple] = None
-        self._cache_names: list[str] = []
-
-    def _live_command_names(self) -> list[str]:
-        cmds = self._commands_provider() or {}
-        meta = self._meta_provider() or {}
-        keys = sorted(set(cmds.keys()) | set(meta.keys()))
-        sig = (len(keys), tuple(keys[:8]))
-        if self._cache_key == sig:
-            return self._cache_names
-        self._cache_key = sig
-        self._cache_names = keys
-        return keys
-
-    def get_completions(self, document, complete_event):  # type: ignore[override]
-        text = document.text_before_cursor
-        if not text.startswith("/"):
-            return
-
-        meta = self._meta_provider() or {}
-
-        if " " not in text:
-            word = text[1:]
-            for name in self._live_command_names():
-                if not name.startswith(word):
-                    continue
-                desc, subs = meta.get(name, ("", []))
-                hint = ""
-                if subs:
-                    head = ", ".join(subs[:3])
-                    more = "…" if len(subs) > 3 else ""
-                    hint = f"  [{head}{more}]"
-                yield Completion(
-                    "/" + name,
-                    start_position=-len(text),
-                    display=ANSI(f"\x1b[36m/{name}\x1b[0m"),
-                    display_meta=(desc + hint) if desc else hint.strip(),
-                )
-            return
-
-        head, _, tail = text.partition(" ")
-        cmd = head[1:]
-        meta_entry = meta.get(cmd)
-        if not meta_entry:
-            return
-        subs = meta_entry[1]
-        if not subs:
-            return
-        partial = tail.rsplit(" ", 1)[-1]
-        for sub in subs:
-            if sub.startswith(partial):
-                yield Completion(
-                    sub,
-                    start_position=-len(partial),
-                    display_meta=f"{cmd} subcommand",
-                )
+    global _commands_provider, _meta_provider
+    _commands_provider = commands_provider
+    _meta_provider = meta_provider
 
 
+# ── Completer ────────────────────────────────────────────────────────────────
+if HAS_PROMPT_TOOLKIT:
+
+    class SlashCompleter(Completer):
+        """Two-level completer for slash commands.
+
+        Level 1: /partial  (no space)  → command names.
+        Level 2: /cmd partial           → subcommands listed in the meta dict.
+
+        Providers default to the module-level ones registered via setup(),
+        but can be injected via the constructor for testing.
+        """
+
+        def __init__(
+            self,
+            commands_provider: Optional[Callable[[], dict]] = None,
+            meta_provider: Optional[Callable[[], dict]] = None,
+        ):
+            self._commands_override = commands_provider
+            self._meta_override = meta_provider
+            self._cache_key: Optional[tuple] = None
+            self._cache_names: list[str] = []
+
+        def _get_commands(self) -> dict:
+            provider = self._commands_override or _commands_provider
+            return (provider() if provider else {}) or {}
+
+        def _get_meta(self) -> dict:
+            provider = self._meta_override or _meta_provider
+            return (provider() if provider else {}) or {}
+
+        def _live_command_names(self) -> list[str]:
+            keys = sorted(set(self._get_commands().keys()) | set(self._get_meta().keys()))
+            sig = tuple(keys)
+            if self._cache_key == sig:
+                return self._cache_names
+            self._cache_key = sig
+            self._cache_names = keys
+            return keys
+
+        def get_completions(self, document, complete_event):  # type: ignore[override]
+            text = document.text_before_cursor
+            if not text.startswith("/"):
+                return
+
+            meta = self._get_meta()
+
+            if " " not in text:
+                word = text[1:]
+                for name in self._live_command_names():
+                    if not name.startswith(word):
+                        continue
+                    desc, subs = meta.get(name, ("", []))
+                    hint = ""
+                    if subs:
+                        head = ", ".join(subs[:3])
+                        more = "…" if len(subs) > 3 else ""
+                        hint = f"  [{head}{more}]"
+                    yield Completion(
+                        "/" + name,
+                        start_position=-len(text),
+                        display=ANSI(f"\x1b[36m/{name}\x1b[0m"),
+                        display_meta=(desc + hint) if desc else hint.strip(),
+                    )
+                return
+
+            head, _, tail = text.partition(" ")
+            cmd = head[1:]
+            meta_entry = meta.get(cmd)
+            if not meta_entry:
+                return
+            subs = meta_entry[1]
+            if not subs:
+                return
+            partial = tail.rsplit(" ", 1)[-1]
+            for sub in subs:
+                if sub.startswith(partial):
+                    yield Completion(
+                        sub,
+                        start_position=-len(partial),
+                        display_meta=f"{cmd} subcommand",
+                    )
+
+else:  # pragma: no cover — unreachable when prompt_toolkit is installed
+    class SlashCompleter:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("prompt_toolkit is not installed")
+
+
+# ── Session cache ────────────────────────────────────────────────────────────
 _SESSION = None
+_SESSION_HISTORY_PATH: Optional[Path] = None
 
 
-def _commands_provider() -> dict:
-    import cheetahclaws as _cc
-    return getattr(_cc, "COMMANDS", {}) or {}
-
-
-def _meta_provider() -> dict:
-    import cheetahclaws as _cc
-    return getattr(_cc, "_CMD_META", {}) or {}
+def reset_session() -> None:
+    """Drop the cached session so the next read_line() rebuilds from scratch."""
+    global _SESSION, _SESSION_HISTORY_PATH
+    _SESSION = None
+    _SESSION_HISTORY_PATH = None
 
 
 def _build_session(history_path: Optional[Path]):
     if not HAS_PROMPT_TOOLKIT:
         raise RuntimeError("prompt_toolkit is not installed")
-    completer = SlashCompleter(_commands_provider, _meta_provider)
+    completer = SlashCompleter()
     history = FileHistory(str(history_path)) if history_path else InMemoryHistory()
     style = Style.from_dict({
-        "completion-menu.completion":         "bg:#222222 #cccccc",
-        "completion-menu.completion.current": "bg:#005f87 #ffffff bold",
-        "completion-menu.meta.completion":    "bg:#222222 #808080",
+        "completion-menu.completion":              "bg:#222222 #cccccc",
+        "completion-menu.completion.current":      "bg:#005f87 #ffffff bold",
+        "completion-menu.meta.completion":         "bg:#222222 #808080",
         "completion-menu.meta.completion.current": "bg:#005f87 #eeeeee",
-        "auto-suggestion":                    "#606060 italic",
+        "auto-suggestion":                         "#606060 italic",
     })
     return PromptSession(
         history=history,
@@ -136,9 +171,17 @@ def _build_session(history_path: Optional[Path]):
 
 
 def read_line(prompt_ansi: str, history_path: Optional[Path] = None) -> str:
-    """Read one line of input via prompt_toolkit; caches the session across calls."""
-    global _SESSION
+    """Read one line of input via prompt_toolkit; caches the session across calls.
+
+    The history file passed here MUST NOT be the readline history file — the
+    two line-editors use incompatible formats. See cheetahclaws.repl for the
+    dedicated PT_HISTORY_FILE.
+    """
+    global _SESSION, _SESSION_HISTORY_PATH
+    if _SESSION is not None and _SESSION_HISTORY_PATH != history_path:
+        _SESSION = None
     if _SESSION is None:
         _SESSION = _build_session(history_path)
+        _SESSION_HISTORY_PATH = history_path
     with patch_stdout(raw=True):
         return _SESSION.prompt(ANSI(prompt_ansi))

--- a/ui/input.py
+++ b/ui/input.py
@@ -1,0 +1,144 @@
+"""prompt_toolkit-based REPL input with typing-time slash-command autosuggest.
+
+Falls back silently when prompt_toolkit is not installed (HAS_PROMPT_TOOLKIT is
+then False), letting the existing readline path in cheetahclaws._read_input
+handle input.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+try:
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+    from prompt_toolkit.completion import Completer, Completion
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.history import FileHistory, InMemoryHistory
+    from prompt_toolkit.patch_stdout import patch_stdout
+    from prompt_toolkit.styles import Style
+    HAS_PROMPT_TOOLKIT = True
+except ImportError:
+    HAS_PROMPT_TOOLKIT = False
+
+
+class SlashCompleter(Completer if HAS_PROMPT_TOOLKIT else object):
+    """Two-level completer for slash commands.
+
+    Level 1: /partial  (no space) → command names.
+    Level 2: /cmd partial          → subcommands listed in _CMD_META.
+
+    Sources:
+      - Live COMMANDS dict from cheetahclaws (includes modular/plugin additions).
+      - _CMD_META for description + subcommand hints.
+    """
+
+    def __init__(
+        self,
+        commands_provider: Callable[[], dict],
+        meta_provider: Callable[[], dict],
+    ):
+        self._commands_provider = commands_provider
+        self._meta_provider = meta_provider
+        self._cache_key: Optional[tuple] = None
+        self._cache_names: list[str] = []
+
+    def _live_command_names(self) -> list[str]:
+        cmds = self._commands_provider() or {}
+        meta = self._meta_provider() or {}
+        keys = sorted(set(cmds.keys()) | set(meta.keys()))
+        sig = (len(keys), tuple(keys[:8]))
+        if self._cache_key == sig:
+            return self._cache_names
+        self._cache_key = sig
+        self._cache_names = keys
+        return keys
+
+    def get_completions(self, document, complete_event):  # type: ignore[override]
+        text = document.text_before_cursor
+        if not text.startswith("/"):
+            return
+
+        meta = self._meta_provider() or {}
+
+        if " " not in text:
+            word = text[1:]
+            for name in self._live_command_names():
+                if not name.startswith(word):
+                    continue
+                desc, subs = meta.get(name, ("", []))
+                hint = ""
+                if subs:
+                    head = ", ".join(subs[:3])
+                    more = "…" if len(subs) > 3 else ""
+                    hint = f"  [{head}{more}]"
+                yield Completion(
+                    "/" + name,
+                    start_position=-len(text),
+                    display=ANSI(f"\x1b[36m/{name}\x1b[0m"),
+                    display_meta=(desc + hint) if desc else hint.strip(),
+                )
+            return
+
+        head, _, tail = text.partition(" ")
+        cmd = head[1:]
+        meta_entry = meta.get(cmd)
+        if not meta_entry:
+            return
+        subs = meta_entry[1]
+        if not subs:
+            return
+        partial = tail.rsplit(" ", 1)[-1]
+        for sub in subs:
+            if sub.startswith(partial):
+                yield Completion(
+                    sub,
+                    start_position=-len(partial),
+                    display_meta=f"{cmd} subcommand",
+                )
+
+
+_SESSION = None
+
+
+def _commands_provider() -> dict:
+    import cheetahclaws as _cc
+    return getattr(_cc, "COMMANDS", {}) or {}
+
+
+def _meta_provider() -> dict:
+    import cheetahclaws as _cc
+    return getattr(_cc, "_CMD_META", {}) or {}
+
+
+def _build_session(history_path: Optional[Path]):
+    if not HAS_PROMPT_TOOLKIT:
+        raise RuntimeError("prompt_toolkit is not installed")
+    completer = SlashCompleter(_commands_provider, _meta_provider)
+    history = FileHistory(str(history_path)) if history_path else InMemoryHistory()
+    style = Style.from_dict({
+        "completion-menu.completion":         "bg:#222222 #cccccc",
+        "completion-menu.completion.current": "bg:#005f87 #ffffff bold",
+        "completion-menu.meta.completion":    "bg:#222222 #808080",
+        "completion-menu.meta.completion.current": "bg:#005f87 #eeeeee",
+        "auto-suggestion":                    "#606060 italic",
+    })
+    return PromptSession(
+        history=history,
+        completer=completer,
+        auto_suggest=AutoSuggestFromHistory(),
+        complete_while_typing=True,
+        enable_history_search=False,
+        mouse_support=False,
+        style=style,
+    )
+
+
+def read_line(prompt_ansi: str, history_path: Optional[Path] = None) -> str:
+    """Read one line of input via prompt_toolkit; caches the session across calls."""
+    global _SESSION
+    if _SESSION is None:
+        _SESSION = _build_session(history_path)
+    with patch_stdout(raw=True):
+        return _SESSION.prompt(ANSI(prompt_ansi))


### PR DESCRIPTION
Replace the Tab-only readline completer with a prompt_toolkit PromptSession that renders an inline ghost suggestion while typing and a keyboard-selectable completion menu.
Fixes three user-visible defects in the REPL:

    1. No as-you-type suggestion — completion only fired on Tab.
    2. The popped-up match list was not selectable (no menu-complete binding, no arrow-key handling; the display hook was pure stdout.write).
    3. Typing `/c` followed by more input dispatched as `/c/cwd` → "Unknown command", because `/` had been removed from readline's word delimiters and `handle_slash` splits only on whitespace.

Also surfaces modular/plugin/skill commands in completion for the first time. The previous completer read only the hand-maintained `_CMD_META` dict, while the dispatcher consulted the full live `COMMANDS` registry.