### PR TITLE
feat(deepseek): adapt to DeepSeek v4 thinking-mode protocol

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -186,11 +186,18 @@ def run(
             break
 
         # Record assistant turn in neutral format
-        state.messages.append({
+        _assistant_msg = {
             "role":       "assistant",
             "content":    assistant_turn.text,
             "tool_calls": assistant_turn.tool_calls,
-        })
+        }
+        # DeepSeek v4 requires reasoning_content to be echoed back on
+        # subsequent requests when the turn contains tool_calls.  Storing it
+        # on the neutral history lets messages_to_openai pass it through.
+        _rc = getattr(assistant_turn, "reasoning_content", "")
+        if _rc and assistant_turn.tool_calls:
+            _assistant_msg["reasoning_content"] = _rc
+        state.messages.append(_assistant_msg)
 
         state.total_input_tokens  += assistant_turn.in_tokens
         state.total_output_tokens += assistant_turn.out_tokens

--- a/providers.py
+++ b/providers.py
@@ -8,7 +8,7 @@ Supported providers:
   kimi       — Moonshot AI (moonshot-v1-8k/32k/128k)
   qwen       — Alibaba DashScope (qwen-max, qwen-plus, ...)
   zhipu      — Zhipu GLM (glm-4, glm-4-plus, ...)
-  deepseek   — DeepSeek (deepseek-chat, deepseek-reasoner, ...)
+  deepseek   — DeepSeek (deepseek-v4-flash, deepseek-v4-pro, deepseek-chat, deepseek-reasoner)
   minimax    — MiniMax (MiniMax-Text-01, abab6.5s-chat, ...)
   ollama     — Local Ollama (llama3.3, qwen2.5-coder, ...)
   lmstudio   — Local LM Studio (any loaded model)
@@ -96,8 +96,9 @@ PROVIDERS: dict[str, dict] = {
         "type":       "openai",
         "api_key_env": "DEEPSEEK_API_KEY",
         "base_url":   "https://api.deepseek.com/v1",
-        "context_limit": 64000,
+        "context_limit": 128000,
         "models": [
+            "deepseek-v4-pro", "deepseek-v4-flash",
             "deepseek-chat", "deepseek-coder", "deepseek-reasoner",
         ],
     },
@@ -158,6 +159,9 @@ COSTS = {
     "qwen-plus":                (0.4,   1.2),
     "deepseek-chat":            (0.27,  1.1),
     "deepseek-reasoner":        (0.55,  2.19),
+    # DeepSeek v4 — pricing placeholder (matches v3 tiers; verify before billing UX)
+    "deepseek-v4-flash":        (0.27,  1.1),
+    "deepseek-v4-pro":          (0.55,  2.19),
     "glm-4-plus":               (0.7,   0.7),
     "MiniMax-Text-01":          (0.7,   2.1),
     "abab6.5s-chat":            (0.1,   0.1),
@@ -229,8 +233,10 @@ _MODEL_OUTPUT_LIMITS: dict[str, int] = {
     "gemini-2.0-flash":             8192,
     "gemini-1.5-pro":               8192,
     # DeepSeek
-    "deepseek-chat":     8192,
-    "deepseek-reasoner": 32768,
+    "deepseek-chat":       8192,
+    "deepseek-reasoner":   32768,
+    "deepseek-v4-flash":   32768,
+    "deepseek-v4-pro":     32768,
 }
 
 # Cache: base_url → {model_id → max_model_len}
@@ -445,6 +451,13 @@ def messages_to_openai(messages: list, ollama_native_images: bool = False) -> li
                     if tc.get("extra_content"):
                         tc_msg["extra_content"] = tc["extra_content"]
                     msg["tool_calls"].append(tc_msg)
+                # DeepSeek v4 spec: when an assistant turn carries tool_calls,
+                # its `reasoning_content` must be echoed back on subsequent
+                # requests.  Benign for other OpenAI-compat providers — they
+                # ignore unknown fields.
+                rc = m.get("reasoning_content")
+                if rc:
+                    msg["reasoning_content"] = rc
             result.append(msg)
 
         elif role == "tool":
@@ -466,15 +479,23 @@ class ThinkingChunk:
     def __init__(self, text): self.text = text
 
 class AssistantTurn:
-    """Completed assistant turn with text + tool_calls."""
+    """Completed assistant turn with text + tool_calls.
+
+    ``reasoning_content`` carries model-emitted chain-of-thought surfaced via an
+    OpenAI-compat ``delta.reasoning_content`` field (DeepSeek v4, Kimi K2
+    Thinking, GLM-4.6, etc.).  DeepSeek v4 requires it to be echoed back when
+    the assistant turn contains tool_calls; see ``messages_to_openai``.
+    """
     def __init__(self, text, tool_calls, in_tokens, out_tokens,
-                 cache_read_tokens=0, cache_write_tokens=0):
+                 cache_read_tokens=0, cache_write_tokens=0,
+                 reasoning_content=""):
         self.text                 = text
         self.tool_calls           = tool_calls   # list of {id, name, input}
         self.in_tokens            = in_tokens
         self.out_tokens           = out_tokens
         self.cache_read_tokens    = cache_read_tokens
         self.cache_write_tokens = cache_write_tokens
+        self.reasoning_content    = reasoning_content
 
 
 def stream_anthropic(
@@ -598,6 +619,16 @@ def stream_openai_compat(
         if not config.get("disable_tool_choice"):
             kwargs["tool_choice"] = "auto"
     _prov = detect_provider(model)
+
+    # DeepSeek v4: thinking is ON by default and controlled via extra_body.
+    # We only inject the toggle when the user explicitly flipped it to False
+    # via /thinking — otherwise we let the provider default stand.
+    if _prov == "deepseek":
+        if config.get("thinking") is False:
+            kwargs.setdefault("extra_body", {})["thinking"] = {"type": "disabled"}
+        eff = config.get("reasoning_effort")
+        if eff:
+            kwargs["reasoning_effort"] = eff
     _effective_mt = resolve_max_tokens(config, _prov, model, base_url, api_key)
     if _effective_mt:
         # Further cap by provider-level max_completion_tokens if present
@@ -613,7 +644,8 @@ def stream_openai_compat(
         else:
             kwargs["max_tokens"] = val
 
-    text          = ""
+    text            = ""
+    reasoning_text  = ""
     tool_buf: dict = {}   # index → {id, name, args_str}
     in_tok = out_tok = 0
     cache_read_tok = cache_write_tok = 0
@@ -630,6 +662,15 @@ def stream_openai_compat(
 
         choice = chunk.choices[0]
         delta  = choice.delta
+
+        # Some providers (DeepSeek v4, Kimi K2 Thinking, GLM-4.6) stream
+        # chain-of-thought on a sibling `reasoning_content` field before any
+        # visible content.  Surface it as ThinkingChunk so the UI renders it
+        # consistently with Anthropic extended-thinking / Ollama thinking.
+        reasoning_delta = getattr(delta, "reasoning_content", None)
+        if reasoning_delta:
+            reasoning_text += reasoning_delta
+            yield ThinkingChunk(reasoning_delta)
 
         if delta.content:
             text += delta.content
@@ -670,7 +711,10 @@ def stream_openai_compat(
             tc_entry["extra_content"] = v["extra_content"]
         tool_calls.append(tc_entry)
 
-    yield AssistantTurn(text, tool_calls, in_tok, out_tok, cache_read_tok, cache_write_tok)
+    yield AssistantTurn(
+        text, tool_calls, in_tok, out_tok, cache_read_tok, cache_write_tok,
+        reasoning_content=reasoning_text,
+    )
 
 
 def stream_ollama(

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -104,7 +104,11 @@ class TestGetContextLimit:
         assert get_context_limit("gemini-2.0-flash") == 1000000
 
     def test_deepseek(self):
-        assert get_context_limit("deepseek-chat") == 64000
+        # Raised to 128K on the v4 update — DeepSeek's real context window
+        # has been 128K since v3, and v4 keeps that.
+        assert get_context_limit("deepseek-chat") == 128000
+        assert get_context_limit("deepseek-v4-pro") == 128000
+        assert get_context_limit("deepseek-v4-flash") == 128000
 
     def test_openai(self):
         assert get_context_limit("gpt-4o") == 128000


### PR DESCRIPTION
## Summary

DeepSeek V4 (`deepseek-v4-pro` / `-flash`) ships thinking mode on by default and splits the response into sibling `reasoning_content` + `content` fields.  Per the [official spec](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode), when an assistant turn contains tool calls, `reasoning_content` must be echoed back on subsequent requests; without tool calls the server drops it.

This PR wires that contract end-to-end:

- **Register v4 models** in `PROVIDERS` / `COSTS` / `_MODEL_OUTPUT_LIMITS`. Bump DeepSeek `context_limit` to 128K (matches the real v3/v4 window — the old 64K was stale).
- **Stream `delta.reasoning_content` as `ThinkingChunk`** in `stream_openai_compat`, same shape the Anthropic and Ollama paths already use. Benign for providers that don't emit the field — also picks up Kimi K2 Thinking / GLM-4.6 as a side benefit.
- **Round-trip `reasoning_content`** through `AssistantTurn` → neutral-format history → `messages_to_openai`.  Only emitted on turns that carry `tool_calls`, matching the spec.
- **Controls** for DeepSeek provider: `config["thinking"] is False` → injects `extra_body={"thinking":{"type":"disabled"}}`; `config["reasoning_effort"]` → top-level kwarg (OpenAI SDK ≥ 1.45 native). Default stance is provider-default (ON), so existing users get thinking for free.
- **Tests**: update `test_deepseek` context-limit assertion to 128K and add v4 model assertions.

## E2E verification

Ran against the live `deepseek-v4-pro` endpoint (three scenarios):

| scenario | result |
|---|---|
| plain completion | 131 chars of `reasoning_content` streamed, final content 32 chars |
| tool-loop | turn 1 emits tool call + reasoning; `messages_to_openai` preserves reasoning on wire (134 chars); turn 2 accepted by server, 187-char answer |
| `thinking: disabled` via config | `reasoning_content` empty, direct answer returned |

## Test plan

- [x] `pytest tests/test_compaction.py` — 34 passed
- [x] live E2E against `deepseek-v4-pro` — all three scenarios pass
- [ ] Maintainer verification against `deepseek-v4-flash` (optional)

## Not included (follow-up)

- `prompts/base/deepseek.md` differentiation — depends on #63 landing first; a small follow-up PR will copy the Anthropic base prompt once the prompts/ package exists on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)