### PR TITLE
fix: enable pytest on Windows by gating PTY-dependent tests

### DIFF
--- a/tests/e2e_slash_prompt.py
+++ b/tests/e2e_slash_prompt.py
@@ -7,12 +7,17 @@ spinning up the full CheetahClaws REPL. Gated on prompt_toolkit availability.
 from __future__ import annotations
 
 import os
-import pty
-import select
 import sys
 import time
+import platform
 
 import pytest
+
+if platform.system() == "Windows":
+    pytest.skip("PTY/termios tests are not supported on Windows", allow_module_level=True)
+
+import pty
+import select
 
 from ui.input import HAS_PROMPT_TOOLKIT
 

--- a/tests/test_skill_nested.py
+++ b/tests/test_skill_nested.py
@@ -23,12 +23,16 @@ class TestIterSkillFiles:
         assert result[0].name == "skill.md"
 
     def test_nested_SKILL_uppercase(self, tmp_path):
+        import platform
         d = tmp_path / "my-skill"
         d.mkdir()
         (d / "SKILL.md").write_text("# My Skill")
         result = list(_iter_skill_files(tmp_path))
         assert len(result) == 1
-        assert result[0].name == "SKILL.md"
+        if platform.system() == "Windows":
+            assert result[0].name.lower() == "skill.md"
+        else:
+            assert result[0].name == "SKILL.md"
 
     def test_mixed_flat_and_nested(self, tmp_path):
         (tmp_path / "flat.md").write_text("# Flat")

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 import httpx
 import pytest
+import platform
+
+if platform.system() == "Windows":
+    pytest.skip("Web API tests are not supported on Windows due to PTY requirements", allow_module_level=True)
 
 # Make the project root importable so `from web import ...` works
 _PKG = Path(__file__).resolve().parent.parent

--- a/web/server.py
+++ b/web/server.py
@@ -16,7 +16,10 @@ import hashlib
 import hmac
 import json
 import os
-import pty
+try:
+    import pty
+except ImportError:
+    pty = None
 import secrets
 import select
 import shutil
@@ -98,6 +101,8 @@ class _PtySession:
     """A PTY session shared between SSE stream and POST input."""
 
     def __init__(self):
+        if not pty:
+            raise RuntimeError("PTY is not supported on this platform")
         self.master_fd, slave_fd = pty.openpty()
         env = os.environ.copy()
         env["TERM"] = "xterm-256color"
@@ -660,6 +665,14 @@ def _handle_websocket(sock: socket.socket, extra: bytes,
                 pass
             return
 
+    try:
+        import pty
+    except ImportError:
+        pty = None
+    if not pty:
+        _send_http(bsock._sock, "501 Not Implemented", "application/json",
+                   b'{"error":"PTY not supported on Windows"}')
+        return
     master_fd, slave_fd = pty.openpty()
     env = os.environ.copy()
     env["TERM"] = "xterm-256color"


### PR DESCRIPTION
## Summary
This PR enables `pytest` to run successfully on Windows environments by gracefully handling Unix-specific dependencies (`pty`, `termios`, `fcntl`). Currently, the test suite and web server crash on Windows due to hard dependencies on these modules. This change ensures that CheetahClaws remains a cross-platform tool while preserving all functionality on Unix-like systems.

## Key Changes

### 1. Test Suite Gating
*   **`tests/e2e_slash_prompt.py`**: Added a module-level `pytest.skip` for Windows. This test relies on terminal emulation and `pty`.
*   **`tests/test_web_api.py`**: Added a module-level skip for Windows. The web terminal bridge requires a PTY to spawn the REPL process.
*   **`tests/test_skill_nested.py`**: Fixed a case-sensitivity assertion for Windows filesystems.

### 2. Web Server Portability
*   **`web/server.py`**: Wrapped `import pty` in a try-except block. If a user attempts to connect to the web terminal on Windows, the server now returns a friendly `501 Not Implemented` error instead of crashing.

## Rationale
Ensuring that `pip install .` and `pytest` work out-of-the-box on Windows is essential for onboarding and CI/CD stability, especially for users in VS Code Dev Containers or native Windows environments.

## Testing Conducted
*   **Windows 11**: Verified that `python -m pytest tests/ -x -q` now finishes with `565 passed, 2 skipped` instead of immediate failures.
*   **Linux (WSL2/Ubuntu)**: Verified that all tests still pass and PTY functionality remains fully operational.

## Checklist
- [x] `python -m pytest tests/ -x -q` passes (with skips on Windows)
- [x] No new dependencies added to core
- [x] Runtime state usage remains unchanged
- [x] No secrets or API keys included