### PR TITLE
fix(tools): make AskUserQuestion synchronous to unblock terminal inpu…

### DIFF
--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -916,10 +916,6 @@ def repl(config: dict, initial_prompt: str = None):
                         if ans_content:
                             _tg_send(ttok, tchat, ans_content)
 
-        # Drain any AskUserQuestion prompts raised during this turn
-        from tools import drain_pending_questions
-        drain_pending_questions(config)
-
         # ── Auto-snapshot after each turn ──
         try:
             tracked = ckpt.get_tracked_edits()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -284,64 +284,37 @@ class TestPluginRecommend:
 # ── AskUserQuestion (via tools module) ────────────────────────────────────────
 
 class TestAskUserQuestion:
-    def test_drain_empty(self):
-        """drain_pending_questions returns False when nothing pending."""
-        from tools import drain_pending_questions, _pending_questions
-        _pending_questions.clear()
-        assert drain_pending_questions({}) is False
-
-    def test_roundtrip_with_freetext(self):
-        """Submit a question, simulate user typing 'yes', collect result."""
+    def test_freetext_answer(self):
+        """User typing free text returns that text verbatim."""
         import tools as _tools
 
-        _tools._pending_questions.clear()
-
-        answered = threading.Event()
-
-        def _submit():
-            result = _tools._ask_user_question("Continue?", allow_freetext=True)
-            assert result == "yes"
-            answered.set()
-
-        t = threading.Thread(target=_submit, daemon=True)
-        t.start()
-
-        import time; time.sleep(0.05)  # let _submit block on event
-
-        # Simulate REPL drain with user input "yes"
         with patch("builtins.input", return_value="yes"):
-            _tools.drain_pending_questions({})
+            result = _tools._ask_user_question("Continue?", allow_freetext=True)
+        assert result == "yes"
 
-        answered.wait(timeout=2)
-        assert answered.is_set()
-
-    def test_roundtrip_with_option_selection(self):
-        """Select option 1 from a numbered list."""
+    def test_option_selection_by_number(self):
+        """Selecting option 1 from a numbered list returns its label."""
         import tools as _tools
-        _tools._pending_questions.clear()
 
-        answered = threading.Event()
-        result_box = []
-
-        def _submit():
-            r = _tools._ask_user_question(
+        with patch("builtins.input", return_value="1"):
+            result = _tools._ask_user_question(
                 "Which?",
                 options=[{"label": "Alpha"}, {"label": "Beta"}],
                 allow_freetext=False,
             )
-            result_box.append(r)
-            answered.set()
+        assert result == "Alpha"
 
-        t = threading.Thread(target=_submit, daemon=True)
-        t.start()
+    def test_option_freetext_via_zero(self):
+        """Typing 0 with allow_freetext prompts for a custom answer."""
+        import tools as _tools
 
-        import time; time.sleep(0.05)
-
-        with patch("builtins.input", return_value="1"):
-            _tools.drain_pending_questions({})
-
-        answered.wait(timeout=2)
-        assert result_box == ["Alpha"]
+        with patch("builtins.input", side_effect=["0", "custom reply"]):
+            result = _tools._ask_user_question(
+                "Pick:",
+                options=[{"label": "Alpha"}],
+                allow_freetext=True,
+            )
+        assert result == "custom reply"
 
     def test_tool_schema_registered(self):
         """AskUserQuestion must appear in TOOL_SCHEMAS."""

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -41,8 +41,8 @@ from tools.diagnostics import (  # noqa: F401
 from tools.interaction import (  # noqa: F401
     _tg_thread_local, _wx_thread_local, _slack_thread_local,
     _is_in_tg_turn, _is_in_wx_turn, _is_in_slack_turn, _is_in_web_turn,
-    _ask_user_question, ask_input_interactive, drain_pending_questions,
-    _sleeptimer, _pending_questions, _ask_lock, _INPUT_WAIT_TIMEOUT,
+    _ask_user_question, ask_input_interactive,
+    _sleeptimer, _INPUT_WAIT_TIMEOUT,
 )
 
 from tool_registry import ToolDef, register_tool
@@ -591,6 +591,7 @@ def _register_builtins() -> None:
             schema=_schemas["AskUserQuestion"],
             func=lambda p, c: _ask_user_question(
                 p["question"], p.get("options"), p.get("allow_freetext", True),
+                config=c,
             ),
             read_only=True, concurrent_safe=False,
         ),

--- a/tools/interaction.py
+++ b/tools/interaction.py
@@ -37,10 +37,7 @@ def _is_in_web_turn(config: dict) -> bool:
     return bool(getattr(runtime.get_ctx(config), 'in_web_turn', False))
 
 
-# ── AskUserQuestion state ─────────────────────────────────────────────────
-
-_pending_questions: list[dict] = []
-_ask_lock = threading.Lock()
+# ── AskUserQuestion ───────────────────────────────────────────────────────
 
 _INPUT_WAIT_TIMEOUT = 300  # seconds before a remote input request times out
 
@@ -49,25 +46,54 @@ def _ask_user_question(
     question: str,
     options: list[dict] | None = None,
     allow_freetext: bool = True,
+    config: dict | None = None,
 ) -> str:
-    """Block the agent loop and surface a question to the user in the terminal."""
-    event         = threading.Event()
-    result_holder: list[str] = []
-    entry = {
-        "question":     question,
-        "options":      options or [],
-        "allow_freetext": allow_freetext,
-        "event":        event,
-        "result":       result_holder,
-    }
-    with _ask_lock:
-        _pending_questions.append(entry)
+    """Render a question to the user and synchronously return their answer.
 
-    event.wait(timeout=300)
+    Runs in the agent thread that invoked the tool: prints the question,
+    then delegates to ``ask_input_interactive`` so terminal/Telegram/WeChat/
+    Slack/Web bridges all read input through their normal path.
+    """
+    config = config or {}
+    options = options or []
 
-    if result_holder:
-        return result_holder[0]
-    return "(no answer — timeout)"
+    print()
+    print("\033[1;35m❓ Question from assistant:\033[0m")
+    print(f"   {question}")
+
+    if options:
+        print()
+        for i, opt in enumerate(options, 1):
+            label = opt.get("label", "")
+            desc  = opt.get("description", "")
+            line  = f"  [{i}] {label}"
+            if desc:
+                line += f" — {desc}"
+            print(line)
+        if allow_freetext:
+            print("  [0] Type a custom answer")
+        print()
+
+        while True:
+            raw = ask_input_interactive(
+                "Your choice (number or text): ", config
+            ).strip()
+            if not raw:
+                return ""
+            if raw.isdigit():
+                idx = int(raw)
+                if 1 <= idx <= len(options):
+                    return options[idx - 1].get("label", "")
+                if idx == 0 and allow_freetext:
+                    return ask_input_interactive("Your answer: ", config).strip()
+                print(f"Invalid option: {idx}")
+                continue
+            if allow_freetext:
+                return raw
+            print("Please choose a number from the list.")
+
+    print()
+    return ask_input_interactive("Your answer: ", config).strip()
 
 
 # ── ask_input_interactive (bridge routing) ────────────────────────────────
@@ -160,71 +186,6 @@ def ask_input_interactive(prompt: str, config: dict,
     except (KeyboardInterrupt, EOFError):
         print()
         return ""
-
-
-# ── drain_pending_questions ───────────────────────────────────────────────
-
-def drain_pending_questions(config: dict) -> bool:
-    """Render any pending AskUserQuestion calls and collect user answers."""
-    with _ask_lock:
-        pending = list(_pending_questions)
-        _pending_questions.clear()
-
-    if not pending:
-        return False
-
-    for entry in pending:
-        question = entry["question"]
-        options  = entry["options"]
-        allow_ft = entry["allow_freetext"]
-        event    = entry["event"]
-        result   = entry["result"]
-
-        print()
-        print("\033[1;35m❓ Question from assistant:\033[0m")
-        print(f"   {question}")
-
-        if options:
-            print()
-            for i, opt in enumerate(options, 1):
-                label = opt.get("label", "")
-                desc  = opt.get("description", "")
-                line  = f"  [{i}] {label}"
-                if desc:
-                    line += f" — {desc}"
-                print(line)
-            if allow_ft:
-                print("  [0] Type a custom answer")
-            print()
-
-            while True:
-                raw = ask_input_interactive(
-                    "Your choice (number or text): ", config
-                ).strip()
-                if not raw:
-                    break
-                if raw.isdigit():
-                    idx = int(raw)
-                    if 1 <= idx <= len(options):
-                        raw = options[idx - 1]["label"]
-                        break
-                    elif idx == 0 and allow_ft:
-                        raw = ask_input_interactive("Your answer: ", config).strip()
-                        break
-                    else:
-                        print(f"Invalid option: {idx}")
-                        raw = ""
-                        continue
-                elif allow_ft:
-                    break
-        else:
-            print()
-            raw = ask_input_interactive("Your answer: ", config).strip()
-
-        result.append(raw)
-        event.set()
-
-    return True
 
 
 # ── SleepTimer ────────────────────────────────────────────────────────────


### PR DESCRIPTION
…t (#69)

The previous queue+event design deadlocked the agent: _ask_user_question appended to _pending_questions and blocked the agent thread on event.wait(timeout=300), but drain_pending_questions only ran AFTER the generator returned — which never happened because the agent thread was blocked. The terminal would freeze and refuse input (and Ctrl-C, since Event.wait can swallow SIGINT).

Bridges (Telegram/WeChat/Slack/Web) worked only because their listener threads set the input event externally; the terminal had no such helper.

Render the question and read the answer synchronously inside the tool call, delegating to ask_input_interactive so all bridges keep using their existing input paths. Drop the _pending_questions queue, _ask_lock, and drain_pending_questions; remove the post-turn drain in cheetahclaws.py.