### PR TITLE
fix(providers): emit content:"" instead of null for tool-only assista…

### DIFF
--- a/error_classifier.py
+++ b/error_classifier.py
@@ -16,6 +16,7 @@ class ErrorCategory(Enum):
     OVERLOADED = "overloaded"
     CONNECTION = "connection"
     TIMEOUT = "timeout"
+    INVALID_REQUEST = "invalid_request"
     UNKNOWN = "unknown"
 
 
@@ -57,6 +58,13 @@ _PATTERNS: list[tuple[ErrorCategory, re.Pattern]] = [
     (ErrorCategory.CONNECTION, re.compile(
         r"connect|refused|unreachable|dns|network|ECONNR|broken.?pipe|reset.?by.?peer",
         re.IGNORECASE)),
+    # 400 / BadRequest: the request body itself is malformed. Retrying the
+    # exact same payload will fail again and just burns circuit-breaker
+    # budget — classify as non-retryable. Keep this AFTER more specific
+    # patterns (rate-limit / context-overflow) so they win when they apply.
+    (ErrorCategory.INVALID_REQUEST, re.compile(
+        r"bad.?request|400|invalid.?message.?content|malformed.?request",
+        re.IGNORECASE)),
 ]
 
 _HINTS = {
@@ -77,6 +85,9 @@ _HINTS = {
         "Request timed out. Will retry.",
     ErrorCategory.CONNECTION:
         "Network error — check your internet connection or the API endpoint URL.",
+    ErrorCategory.INVALID_REQUEST:
+        "The request was rejected as malformed. Try /clear to drop the bad turn, "
+        "or switch model with /model.",
     ErrorCategory.UNKNOWN:
         "An unexpected error occurred.",
 }
@@ -112,7 +123,9 @@ def classify(exc: Exception) -> ClassifiedError:
             cat = ErrorCategory.CONNECTION
         elif isinstance(exc, urllib.error.HTTPError):
             code = exc.code
-            if code == 401 or code == 403:
+            if code == 400:
+                cat = ErrorCategory.INVALID_REQUEST
+            elif code == 401 or code == 403:
                 cat = ErrorCategory.AUTH
             elif code == 402:
                 cat = ErrorCategory.BILLING
@@ -127,7 +140,8 @@ def classify(exc: Exception) -> ClassifiedError:
 
     # Build recovery hints per category
     retryable = cat not in (ErrorCategory.AUTH, ErrorCategory.BILLING,
-                            ErrorCategory.MODEL_NOT_FOUND)
+                            ErrorCategory.MODEL_NOT_FOUND,
+                            ErrorCategory.INVALID_REQUEST)
     should_compress = cat == ErrorCategory.CONTEXT_OVERFLOW
     backoff_multiplier = 3.0 if cat in (ErrorCategory.RATE_LIMIT,
                                          ErrorCategory.OVERLOADED) else 1.0
@@ -136,6 +150,10 @@ def classify(exc: Exception) -> ClassifiedError:
     if cat == ErrorCategory.CONNECTION and ("ollama" in err_str.lower()
             or "localhost" in err_str.lower() or "11434" in err_str):
         hint = "Cannot connect to Ollama. Is it running? Start with: ollama serve"
+    elif cat == ErrorCategory.INVALID_REQUEST and \
+            "invalid message content type" in err_str.lower():
+        hint = ("Ollama rejected an assistant turn with null content. "
+                "Update CheetahClaws (issue #71) or run /clear to drop the bad turn.")
 
     return ClassifiedError(
         category=cat,

--- a/providers.py
+++ b/providers.py
@@ -434,7 +434,11 @@ def messages_to_openai(messages: list, ollama_native_images: bool = False) -> li
             result.append(msg_out)
 
         elif role == "assistant":
-            msg: dict = {"role": "assistant", "content": m.get("content") or None}
+            # Use "" rather than None for the all-tool-calls case: Ollama's
+            # OpenAI-compat endpoint rejects content: null with
+            # `invalid message content type: <nil>` (issue #71). Empty string
+            # is accepted by every OpenAI-compat backend we target.
+            msg: dict = {"role": "assistant", "content": m.get("content") or ""}
             tcs = m.get("tool_calls", [])
             if tcs:
                 msg["tool_calls"] = []


### PR DESCRIPTION
…nt turns (#71)

When an assistant turn only carries tool_calls (no visible text), the neutral history stores content="" but messages_to_openai serialized it as content:null via `m.get("content") or None`. OpenAI accepts null for this case, but Ollama's OpenAI-compat endpoint rejects it with 400 `invalid message content type: <nil>`. Empty string is accepted by all target backends.

Also: classify 400 / BadRequestError as a new INVALID_REQUEST category that is non-retryable. Previously a 400 fell into UNKNOWN (retryable), so the same broken payload was retried 3 times, exhausted the circuit breaker budget and triggered the 120s cooldown — blocking the entire session even though the request body, not the network, was the problem. Match urllib HTTPError(code=400) explicitly and add a targeted hint when the error string contains `invalid message content type`.