### PR TITLE
feat(daemon): F-1 foundation — discovery, system methods, daemon CLI, health, e2e (on top of cc_daemon spike)

### DIFF
--- a/cc_daemon/cli.py
+++ b/cc_daemon/cli.py
@@ -1,23 +1,38 @@
-"""cli.py — `cheetahclaws spike-daemon` subcommand.
+"""cli.py — `cheetahclaws serve` entry point.
 
-Subcommands:
-  serve [--listen unix|tcp://...]   Start the daemon. Default unix socket.
-  status                             Print daemon status / pidfile.
-  stop                               Send SIGTERM to the running daemon.
-  rotate-token                       Regenerate the TCP bearer token.
+The interactive daemon-control verbs (`cheetahclaws daemon status / stop /
+logs / rotate-token`) live in :mod:`commands.daemon_cmd`; this module is
+just the long-running serve loop.
+
+Layered on top of the spike's `make_tcp_server` / `make_unix_server`
+constructors, with these additions for the foundation:
+
+* Calls :func:`bootstrap.bootstrap` so logging / tool registry are wired
+  up the same way as the REPL.
+* Pins ``log_file`` to ``<data_dir>/logs/daemon.log`` (overridable via
+  user config) so ``cheetahclaws daemon logs`` has signal to tail.
+* Threads the loaded ``config`` and ``unauthenticated_metrics`` flag
+  through ``DaemonState`` so ``/healthz`` / ``/readyz`` / ``/metrics``
+  return real ``health.py`` payloads.
+* Writes ``~/.cheetahclaws/daemon.json`` (discovery) on bind and removes
+  it on exit, in addition to the spike's pid file.
+* Watches ``DaemonState.shutdown_event`` so ``system.shutdown`` over RPC
+  triggers graceful exit cross-platform (Windows can't deliver SIGTERM
+  cleanly to another Python process).
 """
 from __future__ import annotations
 
 import argparse
 import os
 import signal
-import socket
 import sys
-import time
+import threading
 from pathlib import Path
 from typing import Optional
 
-from .auth import load_or_create_token, rotate_token
+from . import discovery
+from .auth import load_or_create_token
+
 
 DEFAULT_DATA_DIR = Path.home() / ".cheetahclaws"
 DEFAULT_RUN_DIR = DEFAULT_DATA_DIR / "run"
@@ -26,83 +41,171 @@ DEFAULT_TOKEN_PATH = DEFAULT_DATA_DIR / "daemon_token"
 DEFAULT_PID_FILE = DEFAULT_RUN_DIR / "daemon.pid"
 
 
-def _parse_listen(spec: str) -> tuple[str, object]:
-    """Return ('unix', Path) or ('tcp', (host, port))."""
+# ── --listen parsing ───────────────────────────────────────────────────────
+
+def parse_listen(spec: str) -> tuple[str, object]:
+    """Return ``("unix", Path)`` or ``("tcp", (host, port))``."""
     if spec.startswith("unix://"):
         return "unix", Path(spec[len("unix://"):]).expanduser()
     if spec.startswith("tcp://"):
         host_port = spec[len("tcp://"):]
         if ":" not in host_port:
             raise ValueError(f"tcp listen must be tcp://host:port, got {spec!r}")
-        host, port = host_port.rsplit(":", 1)
-        return "tcp", (host, int(port))
-    raise ValueError(f"unknown listen spec {spec!r}; use unix://path or tcp://host:port")
+        host, port_s = host_port.rsplit(":", 1)
+        if not host:
+            raise ValueError(f"tcp listen host empty: {spec!r}")
+        try:
+            port = int(port_s)
+        except ValueError as exc:
+            raise ValueError(f"tcp listen port not int: {spec!r}") from exc
+        if not (0 <= port <= 65535):
+            raise ValueError(f"tcp listen port out of range: {spec!r}")
+        return "tcp", (host, port)
+    raise ValueError(
+        f"unknown listen spec {spec!r}; use unix://path or tcp://host:port"
+    )
 
 
-def _write_pidfile(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(str(os.getpid()))
+# ── argparse for `cheetahclaws serve` ─────────────────────────────────────
+
+def _build_serve_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cheetahclaws serve",
+        description="Run the headless cheetahclaws daemon.",
+    )
+    p.add_argument("--listen", default=None,
+                   help=f"unix://path or tcp://host:port "
+                        f"(default unix://{DEFAULT_UNIX_SOCKET})")
+    p.add_argument("--data-dir", default=str(DEFAULT_DATA_DIR),
+                   help="Directory for token / pid / discovery / audit files.")
+    p.add_argument("--token-path", default=str(DEFAULT_TOKEN_PATH),
+                   help="TCP bearer-token file path (TCP transport only).")
+    p.add_argument("--no-audit", action="store_true",
+                   help="Disable audit log (default: on for both transports).")
+    p.add_argument("--print-token", action="store_true",
+                   help="Print the TCP bearer token to stdout (TCP only).")
+    p.add_argument("--unauthenticated-metrics", action="store_true",
+                   help="Serve /healthz, /readyz, /metrics without auth "
+                        "(off by default; opt-in for Prometheus scrapers).")
+    return p
 
 
-def _read_pidfile(path: Path) -> Optional[int]:
-    if not path.exists():
-        return None
-    try:
-        return int(path.read_text().strip())
-    except Exception:
-        return None
+def serve_main(argv: Optional[list[str]] = None) -> int:
+    """Entry point used by ``cheetahclaws serve`` (dispatched from cheetahclaws.py)."""
+    parser = _build_serve_parser()
+    args = parser.parse_args(argv)
+    return cmd_serve(args)
 
 
-def _is_pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except OSError:
-        return False
-
+# ── The actual daemon loop ────────────────────────────────────────────────
 
 def cmd_serve(args: argparse.Namespace) -> int:
     from .server import make_tcp_server, make_unix_server
 
     listen = args.listen or f"unix://{DEFAULT_UNIX_SOCKET}"
-    transport, addr = _parse_listen(listen)
+    try:
+        transport, addr = parse_listen(listen)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if transport == "unix" and os.name == "nt":
+        print("error: Unix sockets unavailable on Windows; "
+              "use --listen tcp://host:port instead.", file=sys.stderr)
+        return 2
+
     data_dir = Path(args.data_dir).expanduser()
-    pid_file = DEFAULT_PID_FILE if args.data_dir == str(DEFAULT_DATA_DIR) else data_dir / "run" / "daemon.pid"
+    pid_file = (DEFAULT_PID_FILE if args.data_dir == str(DEFAULT_DATA_DIR)
+                else data_dir / "run" / "daemon.pid")
 
     existing = _read_pidfile(pid_file)
-    if existing and _is_pid_alive(existing):
+    if existing and discovery.pid_alive(existing):
         print(f"daemon already running (pid={existing})", file=sys.stderr)
         return 1
 
+    # ── Load config + bootstrap (logging, tool registry) ──────────────────
+    from cc_config import load_config
+    from bootstrap import bootstrap as _bootstrap
+    config = load_config()
+    if not config.get("log_file"):
+        log_dir = data_dir / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        config["log_file"] = str(log_dir / "daemon.log")
+    # Bump default log level so `daemon logs` has signal in serve mode.
+    if config.get("log_level", "warn") == "warn":
+        config["log_level"] = "info"
+    _bootstrap(config)
+
+    # Pin the health.py module-level config so default-arg payload helpers
+    # see the model name on every call.
+    import health as _health
+    _health.install_config(config)
+
     audit_enabled = not args.no_audit
     if transport == "unix":
-        server = make_unix_server(addr, data_dir=data_dir, audit_enabled=audit_enabled)
+        server = make_unix_server(
+            addr, data_dir=data_dir,
+            audit_enabled=audit_enabled,
+            unauthenticated_metrics=args.unauthenticated_metrics,
+            config=config,
+        )
         listen_repr = f"unix://{addr}"
+        actual_address = str(addr)
     else:
         token = load_or_create_token(Path(args.token_path).expanduser())
-        host, port = addr  # type: ignore
-        server = make_tcp_server(host, port, data_dir=data_dir, token=token, audit_enabled=audit_enabled)
-        listen_repr = f"tcp://{host}:{port}"
+        host, port = addr  # type: ignore[misc]
+        server = make_tcp_server(
+            host, port, data_dir=data_dir, token=token,
+            audit_enabled=audit_enabled,
+            unauthenticated_metrics=args.unauthenticated_metrics,
+            config=config,
+        )
+        # If port=0 was passed, capture the actual kernel-chosen port.
+        actual_port = server.server_address[1]
+        listen_repr = f"tcp://{host}:{actual_port}"
+        actual_address = f"{host}:{actual_port}"
         if args.print_token:
             print(f"token: {token}")
 
     _write_pidfile(pid_file)
-    print(f"cheetahclaws-daemon listening on {listen_repr} (pid={os.getpid()})")
+
+    # Discovery file — REPL/Web/bridge clients look here to find us.
+    info = discovery.make_info(
+        pid=os.getpid(), transport=transport,
+        address=actual_address, version=_lookup_version(),
+    )
+    try:
+        discovery.write(info)
+    except OSError as exc:
+        print(f"warning: discovery write failed: {exc}", file=sys.stderr)
+
+    print(f"cheetahclaws daemon listening on {listen_repr} (pid={os.getpid()})")
     if audit_enabled:
         print(f"audit log: {data_dir / 'logs' / 'auth.jsonl'}")
 
-    def _shutdown(_signo, _frame):
-        print("shutdown requested", file=sys.stderr)
-        server.daemon_state.shutdown()
-        # ThreadingMixIn server.shutdown() must be called from a different
-        # thread than the one running serve_forever. We're in a signal
-        # handler, which runs on the main thread (the same one in
-        # serve_forever) — schedule shutdown on a side thread.
-        import threading as _t
-        _t.Thread(target=server.shutdown, daemon=True).start()
+    # Graceful-shutdown watcher: when DaemonState.shutdown_event fires
+    # (set by system.shutdown RPC or the signal handler below), trigger
+    # server.shutdown() from a side thread (the spike's invariant: the
+    # same thread as serve_forever cannot call shutdown).
+    def _watch_shutdown():
+        server.daemon_state.shutdown_event.wait()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+    threading.Thread(target=_watch_shutdown,
+                      daemon=True, name="daemon-shutdown-watch").start()
 
-    signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
+    def _signal_shutdown(_signo, _frame):
+        server.daemon_state.shutdown()
+
+    try:
+        signal.signal(signal.SIGTERM, _signal_shutdown)
+        signal.signal(signal.SIGINT, _signal_shutdown)
+        if hasattr(signal, "SIGBREAK"):
+            try:
+                signal.signal(signal.SIGBREAK, _signal_shutdown)  # type: ignore[arg-type]
+            except (ValueError, OSError):
+                pass
+    except (ValueError, OSError):
+        pass
 
     try:
         server.serve_forever(poll_interval=0.5)
@@ -120,76 +223,78 @@ def cmd_serve(args: argparse.Namespace) -> int:
             pid_file.unlink()
         except FileNotFoundError:
             pass
+        try:
+            discovery.clear()
+        except OSError:
+            pass
     return 0
 
 
-def cmd_status(args: argparse.Namespace) -> int:
-    pid = _read_pidfile(DEFAULT_PID_FILE)
-    if pid and _is_pid_alive(pid):
-        print(f"running (pid={pid})")
-        return 0
-    print("not running")
-    return 1
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _read_pidfile(path: Path) -> Optional[int]:
+    if not path.exists():
+        return None
+    try:
+        return int(path.read_text().strip())
+    except Exception:
+        return None
 
 
-def cmd_stop(args: argparse.Namespace) -> int:
-    pid = _read_pidfile(DEFAULT_PID_FILE)
-    if not pid or not _is_pid_alive(pid):
-        print("not running", file=sys.stderr)
-        return 1
-    os.kill(pid, signal.SIGTERM)
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        if not _is_pid_alive(pid):
-            print(f"stopped (pid={pid})")
-            return 0
-        time.sleep(0.1)
-    print(f"timed out waiting for pid {pid}; sending SIGKILL", file=sys.stderr)
-    os.kill(pid, signal.SIGKILL)
-    return 0
+def _write_pidfile(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
 
 
-def cmd_rotate_token(args: argparse.Namespace) -> int:
-    token = rotate_token(Path(args.token_path).expanduser())
-    print(f"new token written to {args.token_path}")
-    if args.print_token:
-        print(f"token: {token}")
-    return 0
+def _lookup_version() -> str:
+    try:
+        import cheetahclaws as _root
+        return getattr(_root, "VERSION", "unknown")
+    except Exception:
+        return "unknown"
 
 
-def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="cheetahclaws spike-daemon")
-    sp = p.add_subparsers(dest="cmd", required=True)
-
-    s = sp.add_parser("serve", help="Start the daemon")
-    s.add_argument("--listen", default=None,
-                   help=f"unix://path or tcp://host:port (default unix://{DEFAULT_UNIX_SOCKET})")
-    s.add_argument("--data-dir", default=str(DEFAULT_DATA_DIR))
-    s.add_argument("--token-path", default=str(DEFAULT_TOKEN_PATH))
-    s.add_argument("--no-audit", action="store_true",
-                   help="Disable audit log (default: on for both transports per RFC review)")
-    s.add_argument("--print-token", action="store_true",
-                   help="Print the TCP bearer token to stdout (TCP only)")
-    s.set_defaults(func=cmd_serve)
-
-    st = sp.add_parser("status", help="Print daemon status")
-    st.set_defaults(func=cmd_status)
-
-    stop = sp.add_parser("stop", help="Stop the running daemon")
-    stop.set_defaults(func=cmd_stop)
-
-    rt = sp.add_parser("rotate-token", help="Regenerate TCP bearer token")
-    rt.add_argument("--token-path", default=str(DEFAULT_TOKEN_PATH))
-    rt.add_argument("--print-token", action="store_true")
-    rt.set_defaults(func=cmd_rotate_token)
-
-    return p
-
+# ── Backward-compat entry: `python -m cc_daemon.cli` ──────────────────────
+#
+# The Cheetahclaws spike branch (RFC 0001-spike-notes.md §"How to run it")
+# documented a subparser CLI with verbs ``serve``, ``status``, ``stop``,
+# and ``rotate-token``.  Foundation moves the canonical surface to
+# ``cheetahclaws serve`` / ``cheetahclaws daemon <action>``, but anyone
+# following the spike notes should still be able to invoke
+# ``python -m cc_daemon.cli ...``.
+#
+# We handle that here by dispatching:
+#   * ``serve``  → the same :func:`serve_main` used by ``cheetahclaws serve``
+#   * ``status`` / ``stop`` / ``logs`` / ``rotate-token``
+#                → :func:`commands.daemon_cmd.dispatch` (the same code path
+#                  used by ``cheetahclaws daemon <action>``)
+#
+# Output / exit codes match the new surface; a few flags from the old
+# spike CLI (``--token-path`` / ``--print-token`` on rotate-token) are
+# silently accepted as a courtesy and ignored.
 
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    return args.func(args)
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if not argv:
+        print(
+            "usage: python -m cc_daemon.cli {serve|status|stop|logs|rotate-token} [options]",
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd = argv[0]
+    if cmd == "serve":
+        return serve_main(argv[1:])
+
+    if cmd in ("status", "stop", "logs", "rotate-token"):
+        # daemon_cmd.dispatch reads cmd from argv[0]
+        from commands.daemon_cmd import dispatch as _daemon_dispatch
+        return _daemon_dispatch(argv)
+
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":

--- a/cc_daemon/discovery.py
+++ b/cc_daemon/discovery.py
@@ -1,0 +1,175 @@
+"""Discovery file: tells clients where a running daemon lives.
+
+The daemon writes ``~/.cheetahclaws/daemon.json`` when it binds, and removes
+it on clean exit.  Clients call :func:`locate` to learn whether a daemon is
+running and how to reach it.
+
+Schema::
+
+    { "pid":        12345,
+      "started_at": "2026-04-30T12:00:00Z",
+      "transport":  "unix" | "tcp",
+      "address":    "/run/user/1000/cheetahclaws/daemon.sock"
+                  | "127.0.0.1:8765",
+      "version":    "3.05.72",
+      "schema":     1 }
+
+Atomic write semantics: writes go through a sibling ``.tmp`` file then
+``os.replace``, so an interrupted write never leaves the discovery file
+half-overwritten.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+
+SCHEMA_VERSION = 1
+DEFAULT_FILENAME = "daemon.json"
+
+
+# ── Path resolution ────────────────────────────────────────────────────────
+
+def get_default_path() -> Path:
+    """Default discovery-file location: ``~/.cheetahclaws/daemon.json``."""
+    from cc_config import CONFIG_DIR
+    return CONFIG_DIR / DEFAULT_FILENAME
+
+
+def _resolve(path: Optional[Path]) -> Path:
+    return path if path is not None else get_default_path()
+
+
+# ── Info builder ───────────────────────────────────────────────────────────
+
+def make_info(*, pid: int, transport: str, address: str,
+              version: str) -> dict:
+    """Build a discovery dict ready for :func:`write`."""
+    return {
+        "pid":        pid,
+        "started_at": datetime.datetime.now(datetime.timezone.utc)
+                              .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "transport":  transport,
+        "address":    address,
+        "version":    version,
+        "schema":     SCHEMA_VERSION,
+    }
+
+
+# ── Read / write / clear ───────────────────────────────────────────────────
+
+def write(info: dict, *, path: Optional[Path] = None) -> None:
+    """Atomically write *info* to the discovery file (mode 0600).
+
+    Writes through a sibling ``.tmp`` file then ``os.replace`` so a crash
+    mid-write cannot corrupt an existing discovery file.  If ``os.replace``
+    fails, the temp file is best-effort removed and the exception bubbles.
+    """
+    p = _resolve(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    data = json.dumps(info, indent=2).encode("utf-8")
+    # Open with 0600 so the file mode is correct from the moment data lands;
+    # avoids a window where a world-readable temp file could be observed.
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+    try:
+        os.replace(str(tmp), str(p))
+    except Exception:
+        # Best-effort cleanup of the temp file; do not mask the real error.
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            pass
+        raise
+
+    # On POSIX, re-assert mode in case umask or filesystem altered it.
+    if os.name != "nt":
+        os.chmod(str(p), 0o600)
+
+
+def read(*, path: Optional[Path] = None) -> Optional[dict]:
+    """Return the parsed discovery file, or ``None`` if absent / unreadable."""
+    p = _resolve(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (FileNotFoundError, IsADirectoryError, PermissionError):
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def clear(*, path: Optional[Path] = None) -> None:
+    """Remove the discovery file.  Idempotent — missing file is not an error."""
+    p = _resolve(path)
+    try:
+        p.unlink()
+    except FileNotFoundError:
+        pass
+
+
+# ── Liveness probe ─────────────────────────────────────────────────────────
+
+def pid_alive(pid: int) -> bool:
+    """Best-effort cross-platform check that *pid* is currently running."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        return _pid_alive_windows(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we don't own it; for our purposes that counts.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    import ctypes
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                   False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+# ── Locate ─────────────────────────────────────────────────────────────────
+
+def locate(*, path: Optional[Path] = None) -> Optional[dict]:
+    """Return discovery info if a live daemon is registered.
+
+    If the file exists but the recorded pid is no longer running the file is
+    auto-cleared and ``None`` is returned, so callers do not need a separate
+    stale-file step.
+    """
+    info = read(path=path)
+    if info is None:
+        return None
+    pid = info.get("pid")
+    if not isinstance(pid, int) or not pid_alive(pid):
+        clear(path=path)
+        return None
+    return info

--- a/cc_daemon/server.py
+++ b/cc_daemon/server.py
@@ -46,9 +46,13 @@ class DaemonState:
         token: Optional[str],
         expected_uid: Optional[int],
         audit_enabled: bool,
+        unauthenticated_metrics: bool = False,
+        config: Optional[dict] = None,
     ) -> None:
         self.transport = transport
         self.data_dir = data_dir
+        self.unauthenticated_metrics = unauthenticated_metrics
+        self.config = config or {}
         self.audit = AuditLog(data_dir / "logs" / "auth.jsonl", enabled=audit_enabled)
         self.gate = AuthGate(
             transport,
@@ -61,6 +65,8 @@ class DaemonState:
         self.permissions.start_janitor()
         self.rpc = RpcRegistry()
         register_methods(self.rpc, self.permissions)
+        from . import system_methods
+        system_methods.register(self.rpc, self)
         self.shutdown_event = threading.Event()
 
     def shutdown(self) -> None:
@@ -88,12 +94,13 @@ class DaemonRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         path = urllib.parse.urlparse(self.path).path
-        if path == "/healthz":
-            self._send_json(200, {"status": "ok"})
+        is_health_path = path in ("/healthz", "/readyz", "/metrics")
+
+        # Health endpoints can opt out of auth (Prometheus scrapers, etc.).
+        if is_health_path and self.state.unauthenticated_metrics:
+            self._serve_health(path)
             return
-        if path == "/readyz":
-            self._send_json(200, {"status": "ready"})
-            return
+
         try:
             auth = self._authenticate()
         except RateLimited:
@@ -102,6 +109,13 @@ class DaemonRequestHandler(BaseHTTPRequestHandler):
         except Unauthenticated:
             self._send_error(401, "unauthenticated")
             return
+
+        if is_health_path:
+            # Auth passed; skip the API-version gate so a monitoring tool
+            # that doesn't speak our protocol can still scrape.
+            self._serve_health(path)
+            return
+
         if not self._check_api_version():
             return
         client_id = self._resolve_client_id(auth)
@@ -109,6 +123,19 @@ class DaemonRequestHandler(BaseHTTPRequestHandler):
             self._handle_events(client_id)
             return
         self._send_error(404, "not found")
+
+    # ── Health helpers ────────────────────────────────────────────────────
+
+    def _serve_health(self, path: str) -> None:
+        try:
+            import health as _health
+            payload = _health.payload_for(path, self.state.config)
+        except Exception:
+            payload = {"status": "ok"}
+        code = 200
+        if path == "/readyz" and payload.get("status") == "degraded":
+            code = 503
+        self._send_json(code, payload)
 
     def do_POST(self) -> None:
         path = urllib.parse.urlparse(self.path).path
@@ -284,29 +311,35 @@ class ThreadedTCPServer(socketserver.ThreadingMixIn, HTTPServer):
     daemon_state: DaemonState  # set after construction
 
 
-class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
-    daemon_threads = True
-    request_queue_size = 256
-    daemon_state: DaemonState
+# UnixStreamServer is unavailable on Windows; build the subclass only where
+# socketserver exposes it.  Code paths that try to construct one on Windows
+# raise from the helpers below instead.
+ThreadedUnixServer = None  # type: ignore[assignment]
+if hasattr(socketserver, "UnixStreamServer"):
+    class ThreadedUnixServer(socketserver.ThreadingMixIn,                    # type: ignore[no-redef]
+                              socketserver.UnixStreamServer):
+        daemon_threads = True
+        request_queue_size = 256
+        daemon_state: DaemonState
 
-    # BaseHTTPRequestHandler reads `client_address` to fill log entries; for
-    # Unix sockets `accept()` returns ("", None). Synthesize a stable repr.
-    def get_request(self):
-        sock, _ = self.socket.accept()
-        return sock, ("unix-socket", 0)
+        # BaseHTTPRequestHandler reads `client_address` to fill log entries; for
+        # Unix sockets `accept()` returns ("", None). Synthesize a stable repr.
+        def get_request(self):
+            sock, _ = self.socket.accept()
+            return sock, ("unix-socket", 0)
 
-    def server_bind(self):
-        # Remove leftover socket file from a prior crash, then bind.
-        path = self.server_address
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            pass
-        # Ensure parent dir is 0700 before bind.
-        Path(path).parent.mkdir(parents=True, exist_ok=True)
-        os.chmod(Path(path).parent, 0o700)
-        super().server_bind()
-        os.chmod(path, 0o600)
+        def server_bind(self):
+            # Remove leftover socket file from a prior crash, then bind.
+            path = self.server_address
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            # Ensure parent dir is 0700 before bind.
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            os.chmod(Path(path).parent, 0o700)
+            super().server_bind()
+            os.chmod(path, 0o600)
 
 
 # ── Construction helpers ─────────────────────────────────────────────────────
@@ -319,6 +352,8 @@ def make_tcp_server(
     data_dir: Path,
     token: str,
     audit_enabled: bool = True,
+    unauthenticated_metrics: bool = False,
+    config: Optional[dict] = None,
 ) -> ThreadedTCPServer:
     server = ThreadedTCPServer((host, port), DaemonRequestHandler)
     server.daemon_state = DaemonState(
@@ -327,6 +362,8 @@ def make_tcp_server(
         token=token,
         expected_uid=None,
         audit_enabled=audit_enabled,
+        unauthenticated_metrics=unauthenticated_metrics,
+        config=config,
     )
     return server
 
@@ -337,7 +374,14 @@ def make_unix_server(
     data_dir: Path,
     expected_uid: Optional[int] = None,
     audit_enabled: bool = True,
-) -> ThreadedUnixServer:
+    unauthenticated_metrics: bool = False,
+    config: Optional[dict] = None,
+):
+    if ThreadedUnixServer is None:
+        raise RuntimeError(
+            "Unix-socket transport is unavailable on this platform "
+            "(socketserver.UnixStreamServer missing); use TCP loopback instead."
+        )
     server = ThreadedUnixServer(str(socket_path), DaemonRequestHandler)
     if expected_uid is None:
         expected_uid = os.geteuid()
@@ -347,5 +391,7 @@ def make_unix_server(
         token=None,
         expected_uid=expected_uid,
         audit_enabled=audit_enabled,
+        unauthenticated_metrics=unauthenticated_metrics,
+        config=config,
     )
     return server

--- a/cc_daemon/system_methods.py
+++ b/cc_daemon/system_methods.py
@@ -1,0 +1,44 @@
+"""system_methods.py — Always-available daemon-control RPC methods.
+
+These ride on top of the spike's :mod:`cc_daemon.methods` (which carries
+the demo and permission methods) so the contract surface is the same on
+day one as it will be once the real ``agent.run`` integration lands.
+
+  ``system.ping``      — returns the literal string ``"pong"``.
+                          Same purpose as ``echo.ping`` but matches the
+                          method name committed to in RFC 0001 and the
+                          F-1 acceptance criteria.
+
+  ``system.shutdown``  — triggers ``DaemonState.shutdown()`` which sets
+                          ``shutdown_event``.  The cli.py serve loop
+                          watches that event and, on a side thread,
+                          invokes ``server.shutdown()`` so the ongoing
+                          RPC response can finish writing before the
+                          listener tears down.
+
+                          This is the only cross-platform graceful
+                          shutdown we have — Windows can't deliver
+                          SIGTERM cleanly to another Python process, so
+                          relying on signals would force users on Windows
+                          to ``TerminateProcess`` (no clean cleanup).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .rpc import RpcRegistry
+
+if TYPE_CHECKING:
+    from .server import DaemonState
+
+
+def register(registry: RpcRegistry, daemon_state: "DaemonState") -> None:
+    def system_ping(_params, _ctx):
+        return "pong"
+
+    def system_shutdown(_params, _ctx):
+        daemon_state.shutdown()
+        return "shutdown_initiated"
+
+    registry.register("system.ping", system_ping)
+    registry.register("system.shutdown", system_shutdown)

--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -1494,10 +1494,23 @@ def repl(config: dict, initial_prompt: str = None):
 
 def main():
     # Subcommand short-circuit: avoid colliding with the positional `prompt`
-    # parser. `cheetahclaws spike-daemon ...` dispatches into daemon.cli.
+    # parser.  `cheetahclaws serve` runs the daemon; `cheetahclaws daemon
+    # <action>` is the daemon-control verb (status / stop / logs /
+    # rotate-token).  See docs/RFC/0001-daemon-design-note.md and
+    # docs/RFC/0002-daemon-foundation-roadmap.md.
+    if len(sys.argv) >= 2 and sys.argv[1] == "serve":
+        from cc_daemon.cli import serve_main as _serve_main
+        sys.exit(_serve_main(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "daemon":
+        from commands.daemon_cmd import dispatch as _daemon_dispatch
+        sys.exit(_daemon_dispatch(sys.argv[2:]))
+    # Backward-compat alias for the spike's `cheetahclaws spike-daemon ...`
+    # surface (referenced in docs/RFC/0001-spike-notes.md).  Routes through
+    # the same paths as `serve` / `daemon <action>` so spike-notes commands
+    # keep working unchanged.
     if len(sys.argv) >= 2 and sys.argv[1] == "spike-daemon":
-        from cc_daemon.cli import main as _daemon_main
-        sys.exit(_daemon_main(sys.argv[2:]))
+        from cc_daemon.cli import main as _legacy_main
+        sys.exit(_legacy_main(sys.argv[2:]))
 
     parser = argparse.ArgumentParser(
         prog="cheetahclaws",

--- a/commands/daemon_cmd.py
+++ b/commands/daemon_cmd.py
@@ -1,0 +1,306 @@
+"""commands/daemon_cmd.py — `cheetahclaws daemon {status, stop, logs, rotate-token}`.
+
+Dispatched from :func:`cheetahclaws.main` when the first positional argv
+is ``daemon``.  All actions read the discovery file written by
+``cheetahclaws serve``; absence of that file means "no daemon running".
+
+Auth + token storage live in :mod:`cc_daemon.auth`; discovery in
+:mod:`cc_daemon.discovery`.
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from cc_daemon import auth as _auth
+from cc_daemon import discovery as _discovery
+
+
+LOG_DIR_NAME = "logs"
+LOG_FILENAME = "daemon.log"
+DEFAULT_TAIL_LINES = 50
+RPC_TIMEOUT_S = 2.0
+STOP_WAIT_S = 5.0
+
+# Default token path matches cc_daemon.cli.DEFAULT_TOKEN_PATH; resolved
+# lazily via _default_token_path() so unit tests can monkeypatch it.
+
+
+def _default_token_path() -> Path:
+    from cc_daemon.cli import DEFAULT_TOKEN_PATH
+    return DEFAULT_TOKEN_PATH
+
+
+# ── Top-level dispatch ─────────────────────────────────────────────────────
+
+def dispatch(argv: list[str]) -> int:
+    if not argv:
+        print("usage: cheetahclaws daemon {status|stop|logs|rotate-token} [options]",
+              file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "status":
+        return _status(rest)
+    if cmd == "stop":
+        return _stop(rest)
+    if cmd == "logs":
+        return _logs(rest)
+    if cmd == "rotate-token":
+        return _rotate_token(rest)
+    print(f"unknown daemon action: {cmd}", file=sys.stderr)
+    return 2
+
+
+# ── status ─────────────────────────────────────────────────────────────────
+
+def _status(argv: list[str]) -> int:
+    info = _discovery.locate()
+    if info is None:
+        print("cheetahclaws daemon: not running", file=sys.stderr)
+        return 1
+    started = info.get("started_at", "?")
+    uptime_s = _seconds_since(started)
+    print(f"pid:         {info.get('pid', '?')}")
+    print(f"transport:   {info.get('transport', '?')}")
+    print(f"address:     {info.get('address', '?')}")
+    print(f"version:     {info.get('version', '?')}")
+    print(f"started_at:  {started}")
+    if uptime_s is not None:
+        print(f"uptime:      {_format_duration(uptime_s)}")
+
+    ok, payload = _call_rpc("system.ping")
+    if ok and isinstance(payload, dict) and payload.get("result") == "pong":
+        print("ping:        pong")
+        return 0
+    print(f"ping:        FAILED ({payload})", file=sys.stderr)
+    return 2
+
+
+# ── stop ───────────────────────────────────────────────────────────────────
+
+def _stop(argv: list[str]) -> int:
+    info = _discovery.locate()
+    if info is None:
+        print("cheetahclaws daemon: not running", file=sys.stderr)
+        return 0  # already in the desired state
+
+    pid = info.get("pid")
+
+    # Preferred path: graceful shutdown via RPC.
+    rpc_ok, rpc_result = _call_rpc("system.shutdown")
+    if not rpc_ok and isinstance(pid, int) and pid > 0:
+        # Fallback: SIGTERM (POSIX) / TerminateProcess (Windows).
+        try:
+            if os.name == "nt":
+                _terminate_windows(pid)
+            else:
+                os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError) as exc:
+            print(f"warning: signal delivery failed: {exc}", file=sys.stderr)
+
+    # Wait for the daemon to clear its discovery file.
+    deadline = time.monotonic() + STOP_WAIT_S
+    while time.monotonic() < deadline:
+        if _discovery.locate() is None:
+            print("cheetahclaws daemon: stopped")
+            return 0
+        time.sleep(0.1)
+
+    print("cheetahclaws daemon: did not stop within timeout", file=sys.stderr)
+    return 1
+
+
+# ── logs ───────────────────────────────────────────────────────────────────
+
+def _logs(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="cheetahclaws daemon logs",
+                                      description="Print recent daemon log lines.")
+    parser.add_argument("-n", "--lines", type=int, default=DEFAULT_TAIL_LINES,
+                        help=f"Number of trailing lines to print (default {DEFAULT_TAIL_LINES}).")
+    args = parser.parse_args(argv)
+
+    path = _log_path()
+    if not path.exists():
+        print(f"cheetahclaws daemon: no log file at {path}", file=sys.stderr)
+        return 0
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"error: cannot read log: {exc}", file=sys.stderr)
+        return 1
+    lines = text.splitlines()
+    for line in lines[-max(args.lines, 0):]:
+        print(line)
+    return 0
+
+
+# ── rotate-token ───────────────────────────────────────────────────────────
+
+def _rotate_token(argv: list[str]) -> int:
+    token_path = _default_token_path()
+    _auth.rotate_token(token_path)
+    print(f"cheetahclaws: rotated token at {token_path}")
+    info = _discovery.locate()
+    if info and info.get("transport") == "tcp":
+        print("note: existing TCP clients will receive 401 on next request "
+              "until they re-read the token file.")
+    return 0
+
+
+# ── RPC client ─────────────────────────────────────────────────────────────
+
+def _call_rpc(method: str, params: Any = None) -> Tuple[bool, Any]:
+    """Call a JSON-RPC method on the running daemon.
+
+    Returns ``(ok, payload)``.  ``payload`` is the parsed JSON envelope on
+    success or an error string.
+    """
+    info = _discovery.locate()
+    if info is None:
+        return False, "not running"
+    body = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": method,
+        **({"params": params} if params is not None else {}),
+    }).encode("utf-8")
+
+    transport = info.get("transport")
+    address = info.get("address", "")
+    # cc_daemon's server enforces the API-version header; sending it lets
+    # the request through the version gate.
+    from cc_daemon import API_VERSION, API_VERSION_HEADER
+    headers = {"Content-Type": "application/json",
+               "Content-Length": str(len(body)),
+               "Host": "localhost",
+               API_VERSION_HEADER: API_VERSION}
+
+    if transport == "tcp":
+        token = _auth.load_or_create_token(_default_token_path())
+        headers["Authorization"] = f"Bearer {token}"
+        return _post_tcp(address, "/rpc", body, headers)
+    if transport == "unix":
+        return _post_unix(address, "/rpc", body, headers)
+    return False, f"unknown transport: {transport}"
+
+
+def _post_tcp(address: str, path: str, body: bytes,
+              headers: dict) -> Tuple[bool, Any]:
+    host, port_s = address.rsplit(":", 1)
+    try:
+        port = int(port_s)
+    except ValueError:
+        return False, f"bad address: {address}"
+    conn = http.client.HTTPConnection(host, port, timeout=RPC_TIMEOUT_S)
+    try:
+        conn.request("POST", path, body=body, headers=headers)
+        resp = conn.getresponse()
+        raw = resp.read()
+        if resp.status >= 400:
+            return False, f"http {resp.status}: {raw[:200].decode('utf-8','replace')}"
+        try:
+            return True, json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            return False, "non-JSON response"
+    except Exception as exc:
+        return False, str(exc)
+    finally:
+        conn.close()
+
+
+def _post_unix(sock_path: str, path: str, body: bytes,
+               headers: dict) -> Tuple[bool, Any]:
+    """Send a one-shot HTTP request over a Unix domain socket."""
+    if not hasattr(socket, "AF_UNIX"):
+        return False, "Unix sockets not supported on this platform"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(RPC_TIMEOUT_S)
+    try:
+        sock.connect(sock_path)
+        request_lines = [f"POST {path} HTTP/1.1"]
+        for k, v in headers.items():
+            request_lines.append(f"{k}: {v}")
+        request_lines.append("Connection: close")
+        request_lines.append("")
+        request_lines.append("")
+        sock.sendall("\r\n".join(request_lines).encode("ascii") + body)
+        chunks = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+    except Exception as exc:
+        return False, str(exc)
+    finally:
+        sock.close()
+
+    head, _sep, tail = raw.partition(b"\r\n\r\n")
+    if not _sep:
+        return False, "malformed response"
+    status_line = head.split(b"\r\n", 1)[0].decode("ascii", "replace")
+    parts = status_line.split(" ", 2)
+    if len(parts) < 2:
+        return False, f"malformed status line: {status_line!r}"
+    try:
+        status = int(parts[1])
+    except ValueError:
+        return False, f"non-numeric status: {parts[1]!r}"
+    if status >= 400:
+        return False, f"http {status}: {tail[:200].decode('utf-8','replace')}"
+    try:
+        return True, json.loads(tail.decode("utf-8"))
+    except json.JSONDecodeError:
+        return False, "non-JSON response"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _log_path() -> Path:
+    from cc_config import CONFIG_DIR
+    return CONFIG_DIR / LOG_DIR_NAME / LOG_FILENAME
+
+
+def _seconds_since(iso_ts: str) -> Optional[float]:
+    """Best-effort ISO 8601 → seconds-since-now."""
+    try:
+        import datetime as _dt
+        # Strip trailing Z, parse, treat as UTC.
+        ts = iso_ts.rstrip("Z")
+        started = _dt.datetime.fromisoformat(ts).replace(tzinfo=_dt.timezone.utc)
+        now = _dt.datetime.now(_dt.timezone.utc)
+        return max(0.0, (now - started).total_seconds())
+    except Exception:
+        return None
+
+
+def _format_duration(seconds: float) -> str:
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m {s % 60}s"
+    h, rest = divmod(s, 3600)
+    m, sec = divmod(rest, 60)
+    return f"{h}h {m}m {sec}s"
+
+
+def _terminate_windows(pid: int) -> None:
+    """Best-effort TerminateProcess on Windows."""
+    import ctypes
+    PROCESS_TERMINATE = 0x0001
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+    if not handle:
+        return
+    try:
+        kernel32.TerminateProcess(handle, 1)
+    finally:
+        kernel32.CloseHandle(handle)

--- a/docs/RFC/0002-daemon-foundation-roadmap.md
+++ b/docs/RFC/0002-daemon-foundation-roadmap.md
@@ -1,0 +1,185 @@
+# Daemon Foundation Roadmap
+
+- **Status:** Tracking
+- **Refs:** [#68](https://github.com/SafeRL-Lab/cheetahclaws/issues/68), [RFC 0001 design note](./0001-daemon-design-note.md)
+- **Last updated:** 2026-04-30
+
+The "foundation PR" described at the end of [RFC 0001](./0001-daemon-design-note.md) is too big for one reviewable change (~5 KLoC including stdlib HTTP server, auth, JSON-RPC + SSE, SQLite schema, `daemon` CLI, bridges-into-daemon, subprocess-per-agent, and conservative cost defaults). This document splits it into nine stackable PRs and pins the acceptance criteria for each. Implementation follows this index in order; later items can land in parallel once F-1 and F-2 are merged.
+
+## Index
+
+| ID  | Scope                                               | Depends on | Est LoC | Status |
+|-----|-----------------------------------------------------|------------|---------|--------|
+| F-1 | `daemon/` package skeleton; `serve` + `daemon` CLI  | —          | ~1500   | OPEN   |
+| F-2 | SQLite schema + originator-tracked permission flow  | F-1        | ~600    | TODO   |
+| F-3 | `monitor/scheduler` runs in daemon                  | F-2        | ~500    | TODO   |
+| F-4 | `agent_runner` becomes subprocess-per-agent         | F-2        | ~1000   | TODO   |
+| F-5 | `proactive` watcher runs in daemon                  | F-2        | ~200    | TODO   |
+| F-6 | Telegram bridge in daemon                           | F-2        | ~500    | TODO   |
+| F-7 | Slack bridge in daemon                              | F-6        | ~500    | TODO   |
+| F-8 | WeChat bridge in daemon                             | F-6        | ~500    | TODO   |
+| F-9 | Conservative cost-guardrail defaults under `serve`  | F-1        | ~150    | TODO   |
+
+## F-1 — daemon skeleton
+
+**Scope.** Adopt the `cc_daemon/` reference scaffolding from
+[`feature/daemon-spike`](https://github.com/SafeRL-Lab/cheetahclaws/tree/feature/daemon-spike)
+(`server`, `auth`, `originator`, `rpc`, `events`, `permission`, `methods`)
+**as-is** — those modules encode the contract the maintainer reviewed in
+PR #74.  Layer the foundation glue on top:
+
+- `cc_daemon/discovery.py` — atomic `~/.cheetahclaws/daemon.json` so
+  REPL / Web / bridge clients can locate the running daemon (transport,
+  address, version).  Spike's pid file stays for "is anything running?"
+  liveness; discovery answers "where is it?".
+- `cc_daemon/system_methods.py` — registers `system.ping` (returns
+  `"pong"`) and `system.shutdown` (sets `DaemonState.shutdown_event`,
+  giving us cross-platform graceful exit since Windows can't deliver
+  SIGTERM cleanly to another Python process).
+- `cc_daemon/cli.py` — rewritten `serve_main(argv)` that calls
+  `bootstrap()`, pins `log_file` to `<data_dir>/logs/daemon.log`, threads
+  the loaded `config` and the `--unauthenticated-metrics` flag through
+  `DaemonState`, writes the discovery file on bind, watches the shutdown
+  event, and clears discovery on exit.
+- `cc_daemon/server.py` — minimal patch: route `/healthz` `/readyz`
+  `/metrics` through `health.payload_for(path, config)` instead of
+  the spike's stub `{"status": "ok"}`.  Auth-gated by default; opt out
+  via `--unauthenticated-metrics`.  Adds Windows guard around
+  `socketserver.UnixStreamServer` (unavailable on Windows).
+- `commands/daemon_cmd.py` — `cheetahclaws daemon {status, stop, logs,
+  rotate-token}` subcommand handlers.  `status` reads discovery + pings
+  `system.ping`; `stop` calls `system.shutdown` RPC then falls back to
+  SIGTERM / TerminateProcess; `logs` tails `~/.cheetahclaws/logs/daemon.log`;
+  `rotate-token` regenerates the token (notes that existing TCP clients
+  receive 401 until they re-read the file).
+- `health.py` — refactor: extract module-level `healthz_payload(config)`
+  / `readyz_payload(config)` / `metrics_payload(config)` /
+  `payload_for(path, config)` so both the existing standalone health
+  HTTP server and `cc_daemon/server.py` reuse the same
+  circuit-breaker / quota / runtime-registry probes.  No behaviour
+  change for existing `health_check_port` users.
+- `cheetahclaws.py` — main() short-circuit: `cheetahclaws serve`
+  dispatches to `cc_daemon.cli.serve_main`; `cheetahclaws daemon
+  <action>` dispatches to `commands.daemon_cmd.dispatch`.  Replaces the
+  spike's `spike-daemon` shim.
+
+**Acceptance.**
+- `cheetahclaws serve` starts; `cheetahclaws daemon status` reports pid,
+  transport, address, uptime, ping outcome.
+- Unix socket (POSIX): `curl --unix-socket <path> -X POST /rpc
+  -H "Cheetahclaws-Api-Version: 0" -d '{"jsonrpc":"2.0","id":1,"method":"system.ping"}'`
+  returns `{"jsonrpc":"2.0","id":1,"result":"pong"}`.
+- TCP: same call without `Authorization: Bearer <token>` returns 401;
+  with valid token returns 200; sustained bad-token attempts trip the
+  spike's brute-force throttle (429).
+- `curl … GET /events` keeps the stream open; heartbeats arrive at
+  spike's 15 s cadence.
+- `cheetahclaws daemon stop` → `system.shutdown` RPC → discovery file
+  cleared and process exits 0.
+- `cheetahclaws daemon rotate-token` regenerates the token; existing TCP
+  clients receive 401 on next request until they re-read the file.
+- pytest green on Linux, macOS, Windows (TCP-only on Windows; Unix
+  socket tests skip on Windows).
+
+## F-2 — SQLite schema + originator-tracked permission flow
+
+**Scope.** Seven additive tables in `~/.cheetahclaws/sessions.db`; `permission.answer` RPC with originator validation.
+
+**Tables (additive — `sessions` schema untouched).** `agent_runs`, `agent_iterations`, `jobs`, `monitor_subscriptions`, `monitor_reports`, `bridges`, `daemon_events`.
+
+**Deliverables.**
+- `daemon/schema.py` — table DDL + version table; idempotent `init_schema()`.
+- `daemon/events.py` — replay backed by `daemon_events` (replaces F-1's in-memory ring).
+- `daemon/permissions.py` — originator record on every `PermissionRequest`; `permission.answer` checks caller's auth identity against originator; non-originators get `403 not_originator`.
+- `jobs.py` — one-shot migrate `~/.cheetahclaws/jobs.json` into the `jobs` table; JSON file kept readable for one release.
+
+**Acceptance.**
+- Schema migrations run idempotently across daemon restarts.
+- `permission.answer` from the originator succeeds; from any other client returns `403 not_originator`.
+- Originator disconnect + reconnect within timeout window: pending request replays via SSE scoped to that originator.
+- `daemon_events` table caps at configured retention (default 1M rows / 7 days); oldest rows expired.
+- Existing `jobs.json` users see a one-time import message; subsequent runs read from SQLite.
+
+## F-3 — monitor in daemon
+
+**Scope.** `monitor/scheduler.py` runs daemon-side; REPL skips its local thread when a daemon is detected.
+
+**RPC methods.** `monitor.subscribe`, `monitor.unsubscribe`, `monitor.list`, `monitor.run`.
+
+**Acceptance.**
+- `cheetahclaws serve` running → `/monitor subscribe arxiv --schedule daily --telegram` persists to `monitor_subscriptions`; daemon scheduler fires on cadence even after REPL exit.
+- Without daemon: today's behavior unchanged (in-process scheduler thread).
+- Reports persist to `monitor_reports` and emit `monitor_report` SSE events.
+
+## F-4 — agent_runner subprocess
+
+**Scope.** Each `AgentRunner` is its own subprocess. From #68: *"subprocess-per-agent rather than threads — one leaking/crashing runner shouldn't take down the scheduler and bridges."*
+
+**Deliverables.**
+- `daemon/runner_supervisor.py` — spawn / monitor / restart agent-runner subprocesses.
+- `daemon/runner_ipc.py` — line-delimited JSON over stdin/stdout between supervisor and runner.
+- `agent_runner.py` — main entry point usable as `python -m agent_runner --pipe …`; iteration-log writes flow back to the daemon and land in `agent_iterations`.
+- Permission requests from runners routed through supervisor → `daemon/permissions.py`.
+
+**Acceptance.**
+- Runner crash (`kill -9 <runner_pid>`) does not kill the daemon; supervisor logs the crash and emits `agent_runner_crash` event.
+- Runner OOM does not affect monitor or bridges.
+- Runner subprocess stops within 5 s of `agent.stop` RPC.
+- Iteration-log entries match in-process behavior (status, duration, summary, token counts).
+
+## F-5 — proactive watcher in daemon
+
+**Scope.** `_proactive_watcher_loop` from `cheetahclaws.py` becomes a daemon-owned task.
+
+**Acceptance.**
+- `/proactive 5m` while daemon is running: setting persists, sentinel runs in daemon, survives REPL exit.
+- Without daemon: unchanged.
+
+## F-6 / F-7 / F-8 — bridges in daemon (one PR per bridge)
+
+**Scope per PR.** The named bridge (`telegram`, then `slack`, then `wechat`) runs inside daemon; incoming messages enter via `POST /rpc {"method":"session.send", …}`; outgoing replies come from an SSE subscription to that session's events.
+
+**Per-bridge deliverables.**
+- Move `bridges/<kind>.py` poll loop into a daemon-owned worker.
+- Drop `RuntimeContext.<kind>_send` / `<kind>_input_event` and friends; replace with the API-mediated path.
+- `bridge.start` / `bridge.stop` / `bridge.list` RPC methods.
+- Persist bridge state to `bridges` table.
+
+**Acceptance per bridge.**
+- Phone message → daemon `session.send` → REPL/Web/another bridge can subscribe to the same session and see events.
+- Bridge survives REPL exit; user can keep texting.
+- Permission requests originating from a bridge-driven turn route only to that bridge for answer (per RFC 0001 §2).
+
+F-7 depends on F-6 (shared scaffolding); F-8 the same.
+
+## F-9 — cost guardrail defaults under `serve`
+
+**Scope.** When running under `cheetahclaws serve`, the four budget keys default to non-`None`:
+
+```jsonc
+{
+  "session_token_budget": 200000,
+  "session_cost_budget":   2.0,
+  "daily_token_budget":   2000000,
+  "daily_cost_budget":     20.0
+}
+```
+
+REPL `--in-process` mode keeps `None` defaults (no surprise for existing users).
+
+**Acceptance.**
+- `cheetahclaws serve` started without overrides → `cheetahclaws daemon status` reports the four defaults.
+- Agent runner exceeds per-session budget → status moves to `paused_budget`, `quota_warn` event emitted, runner pauses.
+- `agent.resume` RPC with a new budget argument unpauses the runner.
+- REPL without daemon: budgets still default to `None`.
+
+## Cross-cutting conventions
+
+- **Tests.** Every PR ships unit tests; F-1, F-3, F-4, F-6/7/8 also ship `tests/e2e_daemon_<area>.py`.
+- **Docs.** Every PR updates the relevant section in `docs/architecture.md`. The "Daemon" header is created by F-1; subsequent PRs append.
+- **Config keys.** New keys go in `cc_config.DEFAULTS`; documented in `docs/architecture.md`.
+- **Backwards compatibility.** Users who never run `cheetahclaws serve` see no behavior change until the eventual default flip — that flip is out of scope here and tracked in [#68](https://github.com/SafeRL-Lab/cheetahclaws/issues/68) as the "Phase D" item.
+
+## Updating this document
+
+When a PR lands, change its **Status** in the index from `TODO` to `MERGED #<pr>`. If acceptance criteria evolve during a PR, update the per-PR section in the same PR — do not let this doc drift from the implementation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -684,7 +684,122 @@ Optional self-hosted browser-accessible UI, enabled by `[web]` extra
 (`sqlalchemy`, `passlib[bcrypt]`, `PyJWT`).  `web/server.py` runs an
 HTTP server; `web/static/` serves an xterm.js frontend; `web/db.py`
 persists per-user session history in SQLite.  Launched by `/web` slash
-command inside the REPL, or by `cheetahclaws --serve` (TBD).
+command inside the REPL.
+
+The web UI will eventually become a client of the daemon described in
+the next section (per [RFC 0001](RFC/0001-daemon-design-note.md));
+today it stands alone.
+
+### Daemon (`cc_daemon/` + `commands/daemon_cmd.py`)
+
+The headless `cheetahclaws serve` runtime — foundation for the
+"long-running services survive REPL exit" work tracked in
+[issue #68](https://github.com/SafeRL-Lab/cheetahclaws/issues/68).
+Designed in [RFC 0001](RFC/0001-daemon-design-note.md);
+implementation phasing in
+[RFC 0002](RFC/0002-daemon-foundation-roadmap.md).
+Reference scaffolding lives at
+[RFC 0001 spike notes](RFC/0001-spike-notes.md) — the F-1 foundation
+adopts that scaffolding wholesale and layers the integration glue on
+top.
+
+**Module map (foundation = spike + glue).**
+
+Pulled in unchanged from the spike (these encode the wire contract):
+
+- `cc_daemon/__init__.py` — `API_VERSION = "0"`, `API_VERSION_HEADER =
+  "Cheetahclaws-Api-Version"`.
+- `cc_daemon/server.py` — `ThreadedTCPServer` and `ThreadedUnixServer`
+  (the latter conditional on `socketserver.UnixStreamServer`, so
+  Windows skips it cleanly), 256-deep listen backlog, per-connection
+  request handler, SSE loop with 15 s heartbeat, `Cheetahclaws-Api-Version`
+  gate that returns `426` on mismatch.
+- `cc_daemon/auth.py` — `SO_PEERCRED` peer-cred check (Linux; macOS
+  TODO), bearer-token auth for TCP, per-peer brute-force throttle,
+  audit-log default-on for both transports.
+- `cc_daemon/originator.py` — `client_id` mint / persist
+  (`~/.cheetahclaws/clients/<kind>.id`) / resume so disconnect-and-
+  reconnect keeps the originator identity stable.
+- `cc_daemon/rpc.py` — JSON-RPC 2.0 dispatcher.  Application errors
+  `-32001` (`not_originator`) and `-32002` (`unknown_request`) carry
+  HTTP `403` so observers can't answer permission requests they don't
+  own.
+- `cc_daemon/events.py` — in-memory ring buffer + per-subscriber Queue;
+  emits a `gap` event on overflow so SSE clients know to re-sync.  F-2
+  swaps the ring for the `daemon_events` SQLite table without changing
+  the channel API.
+- `cc_daemon/permission.py` — pending-request store, originator-only
+  `answer`, 30 min default interactive timeout + `permission.refresh_timeout`
+  RPC.
+- `cc_daemon/methods.py` — spike's `echo.ping` / `permission.demo` /
+  `permission.answer` / `permission.refresh_timeout` / `permission.list`.
+- `cc_daemon/spike_client.py` — stdlib smoke client, useful for manual
+  debugging; not a runtime dependency.
+
+Added by the F-1 foundation:
+
+- `cc_daemon/discovery.py` — atomic write/read of
+  `~/.cheetahclaws/daemon.json` (pid, transport, address, started_at,
+  schema version) so REPL / Web / bridge clients can locate the daemon.
+  Auto-clears stale files when the recorded pid is no longer alive.
+- `cc_daemon/system_methods.py` — registers `system.ping` (RFC contract
+  name; coexists with spike's `echo.ping`) and `system.shutdown`
+  (triggers `DaemonState.shutdown_event`, our cross-platform graceful
+  exit since Windows can't deliver SIGTERM cleanly to another Python
+  process).
+- `cc_daemon/cli.py` — rewritten `serve_main(argv)` that calls
+  `bootstrap()`, pins `log_file` to `<data_dir>/logs/daemon.log`,
+  threads loaded config + `--unauthenticated-metrics` through
+  `DaemonState`, writes the discovery file on bind, watches the
+  shutdown event, and clears discovery on exit.
+- `commands/daemon_cmd.py` — `cheetahclaws daemon {status, stop, logs,
+  rotate-token}`.  All actions read the discovery file.  `stop` prefers
+  the `system.shutdown` RPC and falls back to SIGTERM /
+  TerminateProcess.  Sends the `Cheetahclaws-Api-Version: 0` header on
+  every RPC.
+- `health.py` — refactored: extracted `healthz_payload(config)` /
+  `readyz_payload(config)` / `metrics_payload(config)` /
+  `payload_for(path, config)` module-level helpers so both the existing
+  standalone health HTTP server and `cc_daemon/server.py` reuse the
+  same circuit-breaker / quota / runtime-registry probes without
+  starting a second listener.
+
+**Wire surface (HTTP/1.1 over UDS or TCP).**
+
+| Verb + path | Purpose |
+|---|---|
+| `POST /rpc` | JSON-RPC 2.0 — methods, batches, notifications.  Requires `Cheetahclaws-Api-Version: 0`. |
+| `GET /events?since=<id>` | SSE event stream (heartbeats every 15 s; `gap` event on backlog overflow). |
+| `GET /healthz` `/readyz` `/metrics` | Real `health.py` payloads, auth-gated by default; `--unauthenticated-metrics` opts out for trusted scrapers. |
+
+**Auth.** Single-user, single-host threat model — see RFC 0001 §3.
+Unix socket relies on file mode `0600` + `SO_PEERCRED`.  TCP requires
+`Authorization: Bearer <token>` against `~/.cheetahclaws/daemon_token`
+(mode `0600`, generated lazily on first `serve --listen tcp://...`).
+Both transports have audit log default-on; per-peer brute-force
+throttle returns `429` after sustained bad attempts.
+
+**Lifecycle.**
+- `cheetahclaws serve [--listen unix://path | tcp://host:port]
+  [--unauthenticated-metrics] [--no-audit] [--print-token]`
+- `cheetahclaws daemon status` — pid, transport, address, uptime,
+  ping check.
+- `cheetahclaws daemon stop` — graceful via RPC, OS signal as fallback.
+- `cheetahclaws daemon logs [-n N]` — tail
+  `~/.cheetahclaws/logs/daemon.log` (the `serve` entrypoint pins
+  `log_file` to that path when not overridden in config).
+- `cheetahclaws daemon rotate-token` — regenerate token; existing TCP
+  clients receive `401` until they re-read the file.
+
+**What's not in F-1 (intentional).**  The daemon currently exposes
+`system.ping`, `system.shutdown`, the spike's `echo.ping`, and the
+permission methods (which work end-to-end against the spike's demo
+flow but aren't yet wired into `agent.run`).  Migrating
+`monitor/scheduler`, `agent_runner` (as subprocess-per-agent),
+`proactive`, the three messaging bridges, and replacing
+`cc_daemon/methods.py` and `cc_daemon/permission.py` with
+`agent.run`-driven equivalents is the F-2 through F-8 work in the
+foundation roadmap.
 
 ---
 

--- a/health.py
+++ b/health.py
@@ -58,69 +58,110 @@ class _HealthHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "not found"})
 
     # ── Payload builders ──────────────────────────────────────────────────
-
-    @staticmethod
-    def _uptime() -> float:
-        return round(time.monotonic() - _start_time, 1)
-
-    @staticmethod
-    def _circuit_states() -> dict[str, str]:
-        try:
-            from circuit_breaker import _registry as _cb_reg, _registry_lock as _cb_lock
-            with _cb_lock:
-                return {p: b.state.value for p, b in _cb_reg.items()}
-        except Exception:
-            return {}
-
-    @staticmethod
-    def _active_sessions() -> int:
-        try:
-            from runtime import _registry as _rt_reg, _registry_lock as _rt_lock
-            with _rt_lock:
-                return len(_rt_reg)
-        except Exception:
-            return 0
+    # The instance methods below delegate to module-level functions so that
+    # other listeners (e.g. daemon/server.py) can reuse the same payload
+    # logic without booting a second http.server.
 
     def _healthz(self) -> dict:
-        return {
-            "status":          "ok",
-            "uptime_s":        self._uptime(),
-            "model":           _config.get("model", ""),
-            "active_sessions": self._active_sessions(),
-        }
+        return healthz_payload(_config)
 
     def _readyz(self) -> dict:
-        circuits = self._circuit_states()
-        open_circuits = [p for p, s in circuits.items() if s == "open"]
-        status = "degraded" if open_circuits else "ok"
-        body = {
-            "status":        status,
-            "uptime_s":      self._uptime(),
-            "circuits":      circuits,
-        }
-        if open_circuits:
-            body["open_circuits"] = open_circuits
-        return body
+        return readyz_payload(_config)
 
     def _metrics(self) -> dict:
-        circuits = self._circuit_states()
-        # Today's quota usage (read from file — best effort)
-        daily_tokens = daily_cost = 0
-        try:
-            from quota import _load_daily, _lock as _q_lock
-            with _q_lock:
-                daily_tokens, daily_cost = _load_daily()
-        except Exception:
-            pass
+        return metrics_payload(_config)
 
-        return {
-            "uptime_s":        self._uptime(),
-            "model":           _config.get("model", ""),
-            "active_sessions": self._active_sessions(),
-            "circuits":        circuits,
-            "daily_tokens":    daily_tokens,
-            "daily_cost_usd":  round(daily_cost, 6),
-        }
+
+# ── Module-level payload helpers ──────────────────────────────────────────
+
+def uptime_seconds() -> float:
+    return round(time.monotonic() - _start_time, 1)
+
+
+def _circuit_states() -> dict[str, str]:
+    try:
+        from circuit_breaker import _registry as _cb_reg, _registry_lock as _cb_lock
+        with _cb_lock:
+            return {p: b.state.value for p, b in _cb_reg.items()}
+    except Exception:
+        return {}
+
+
+def _active_sessions() -> int:
+    try:
+        from runtime import _registry as _rt_reg, _registry_lock as _rt_lock
+        with _rt_lock:
+            return len(_rt_reg)
+    except Exception:
+        return 0
+
+
+def healthz_payload(config: dict | None = None) -> dict:
+    cfg = config if config is not None else _config
+    return {
+        "status":          "ok",
+        "uptime_s":        uptime_seconds(),
+        "model":           (cfg or {}).get("model", ""),
+        "active_sessions": _active_sessions(),
+    }
+
+
+def readyz_payload(config: dict | None = None) -> dict:
+    cfg = config if config is not None else _config
+    circuits = _circuit_states()
+    open_circuits = [p for p, s in circuits.items() if s == "open"]
+    status = "degraded" if open_circuits else "ok"
+    body: dict = {
+        "status":   status,
+        "uptime_s": uptime_seconds(),
+        "circuits": circuits,
+    }
+    if open_circuits:
+        body["open_circuits"] = open_circuits
+    body["model"] = (cfg or {}).get("model", "")
+    return body
+
+
+def metrics_payload(config: dict | None = None) -> dict:
+    cfg = config if config is not None else _config
+    circuits = _circuit_states()
+    # Today's quota usage (read from file — best effort)
+    daily_tokens = daily_cost = 0
+    try:
+        from quota import _load_daily, _lock as _q_lock
+        with _q_lock:
+            daily_tokens, daily_cost = _load_daily()
+    except Exception:
+        pass
+    return {
+        "uptime_s":        uptime_seconds(),
+        "model":           (cfg or {}).get("model", ""),
+        "active_sessions": _active_sessions(),
+        "circuits":        circuits,
+        "daily_tokens":    daily_tokens,
+        "daily_cost_usd":  round(daily_cost, 6),
+    }
+
+
+def payload_for(path: str, config: dict | None = None) -> dict:
+    """Dispatch helper: route an HTTP path to its payload builder."""
+    if path == "/healthz":
+        return healthz_payload(config)
+    if path == "/readyz":
+        return readyz_payload(config)
+    if path == "/metrics":
+        return metrics_payload(config)
+    return {}
+
+
+def install_config(config: dict) -> None:
+    """Pin the module-level config used by start_health_server / server.
+
+    Idempotent — daemon/cli.py calls this when starting the daemon listener
+    so the default-arg payload helpers see the right model/version data.
+    """
+    global _config
+    _config = config
 
 
 # ── Server lifecycle ──────────────────────────────────────────────────────

--- a/tests/e2e_daemon_skeleton.py
+++ b/tests/e2e_daemon_skeleton.py
@@ -1,0 +1,302 @@
+"""End-to-end tests for `cheetahclaws serve` + `cheetahclaws daemon ...`.
+
+These tests boot the *real* daemon as a subprocess, hit it from the test
+process via http.client, and verify discovery / auth / RPC / SSE / shutdown
+behaviour at the process boundary — i.e. the integration the in-process
+``test_daemon_server.py`` cannot cover.
+
+Each test gets an isolated ``$HOME`` so daemon.json / daemon_token / logs
+don't collide with the developer's real state.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── Fixture: boot a real daemon under an isolated HOME ─────────────────────
+
+@pytest.fixture
+def daemon_proc(tmp_path):
+    """Start `cheetahclaws serve --listen tcp://...` in a subprocess.
+
+    Yields ``(proc, home, address, token)``.  Tears the process down by
+    sending the ``system.shutdown`` RPC; falls back to terminate() on
+    timeout.
+    """
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)  # Windows: Path.home() reads this
+    # Pin XDG_RUNTIME_DIR under tmp_path so any UDS path lands here too.
+    env["XDG_RUNTIME_DIR"] = str(tmp_path / "xdg")
+
+    proc = subprocess.Popen(
+        [sys.executable, "cheetahclaws.py", "serve",
+         "--listen", "tcp://127.0.0.1:0"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    cheetah_dir = tmp_path / ".cheetahclaws"
+    discovery_file = cheetah_dir / "daemon.json"
+    token_file = cheetah_dir / "daemon_token"
+
+    # Wait up to 10 s for the daemon to bind and write discovery.
+    deadline = time.monotonic() + 10.0
+    info = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            pytest.fail(
+                "daemon exited before binding\n"
+                f"stdout: {stdout.decode('utf-8', 'replace')}\n"
+                f"stderr: {stderr.decode('utf-8', 'replace')}"
+            )
+        if discovery_file.exists() and token_file.exists():
+            try:
+                info = json.loads(discovery_file.read_text(encoding="utf-8"))
+                break
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.1)
+    if info is None:
+        proc.terminate()
+        proc.wait(timeout=5)
+        pytest.fail("daemon did not write discovery file in time")
+
+    address = info["address"]  # "host:port"
+    token = token_file.read_text(encoding="utf-8").strip()
+
+    yield proc, tmp_path, address, token
+
+    # Teardown: graceful shutdown via RPC, then terminate as fallback.
+    if proc.poll() is None:
+        try:
+            _post_rpc(address, token, "system.shutdown")
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _post_rpc(address: str, token: str, method: str,
+              params=None, *, timeout=3.0):
+    from cc_daemon import API_VERSION, API_VERSION_HEADER
+    host, port_s = address.rsplit(":", 1)
+    body_obj = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        body_obj["params"] = params
+    body = json.dumps(body_obj).encode("utf-8")
+    conn = http.client.HTTPConnection(host, int(port_s), timeout=timeout)
+    try:
+        conn.request("POST", "/rpc", body=body,
+                     headers={"Authorization": f"Bearer {token}",
+                              "Content-Type": "application/json",
+                              API_VERSION_HEADER: API_VERSION})
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, json.loads(raw) if raw else None
+    finally:
+        conn.close()
+
+
+def _get(address: str, path: str, *, token: str | None = None,
+         api_version: bool = False, timeout=3.0):
+    host, port_s = address.rsplit(":", 1)
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    if api_version:
+        from cc_daemon import API_VERSION, API_VERSION_HEADER
+        headers[API_VERSION_HEADER] = API_VERSION
+    conn = http.client.HTTPConnection(host, int(port_s), timeout=timeout)
+    try:
+        conn.request("GET", path, headers=headers)
+        resp = conn.getresponse()
+        return resp.status, resp.read().decode("utf-8", errors="replace")
+    finally:
+        conn.close()
+
+
+def _run_subcommand(args: list[str], home: Path, *, timeout=10.0):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(home / "xdg")
+    proc = subprocess.run(
+        [sys.executable, "cheetahclaws.py", *args],
+        cwd=str(REPO_ROOT), env=env, timeout=timeout,
+        capture_output=True,
+    )
+    return (proc.returncode,
+            proc.stdout.decode("utf-8", "replace"),
+            proc.stderr.decode("utf-8", "replace"))
+
+
+# ── Boot + discovery ───────────────────────────────────────────────────────
+
+def test_daemon_writes_discovery_and_token(daemon_proc):
+    _proc, home, address, token = daemon_proc
+    info_path = home / ".cheetahclaws" / "daemon.json"
+    info = json.loads(info_path.read_text(encoding="utf-8"))
+    assert info["transport"] == "tcp"
+    assert info["address"] == address
+    assert info["pid"] > 0
+    assert info["schema"] == 1
+    assert len(token) >= 32
+
+
+# ── RPC ────────────────────────────────────────────────────────────────────
+
+def test_rpc_system_ping(daemon_proc):
+    _proc, _home, address, token = daemon_proc
+    status, body = _post_rpc(address, token, "system.ping")
+    assert status == 200
+    assert body == {"jsonrpc": "2.0", "id": 1, "result": "pong"}
+
+
+def test_rpc_method_not_found(daemon_proc):
+    _proc, _home, address, token = daemon_proc
+    status, body = _post_rpc(address, token, "no.such.method")
+    assert status == 200  # JSON-RPC errors travel inside the envelope
+    assert body["error"]["code"] == -32601
+
+
+def test_rpc_without_token_returns_401(daemon_proc):
+    _proc, _home, address, _token = daemon_proc
+    host, port_s = address.rsplit(":", 1)
+    body = json.dumps({"jsonrpc": "2.0", "id": 1,
+                       "method": "system.ping"}).encode("utf-8")
+    conn = http.client.HTTPConnection(host, int(port_s), timeout=3.0)
+    try:
+        conn.request("POST", "/rpc", body=body,
+                     headers={"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        resp.read()
+        assert resp.status == 401
+    finally:
+        conn.close()
+
+
+# ── Health endpoints ───────────────────────────────────────────────────────
+
+def test_healthz_requires_auth_by_default(daemon_proc):
+    _proc, _home, address, _token = daemon_proc
+    status, _ = _get(address, "/healthz")  # no token
+    assert status == 401
+
+
+def test_healthz_with_token_returns_real_payload(daemon_proc):
+    _proc, _home, address, token = daemon_proc
+    status, body = _get(address, "/healthz", token=token)
+    assert status == 200
+    payload = json.loads(body)
+    assert payload["status"] == "ok"
+    assert "uptime_s" in payload
+    assert "active_sessions" in payload
+    assert "model" in payload  # health.py reads from cc_config
+
+
+def test_metrics_with_token_returns_real_payload(daemon_proc):
+    _proc, _home, address, token = daemon_proc
+    status, body = _get(address, "/metrics", token=token)
+    assert status == 200
+    payload = json.loads(body)
+    for key in ("uptime_s", "model", "active_sessions", "circuits",
+                "daily_tokens", "daily_cost_usd"):
+        assert key in payload, f"missing {key}"
+
+
+# ── SSE ────────────────────────────────────────────────────────────────────
+
+def test_events_stream_emits_heartbeat(daemon_proc):
+    from cc_daemon import API_VERSION, API_VERSION_HEADER
+    _proc, _home, address, token = daemon_proc
+    host, port_s = address.rsplit(":", 1)
+    conn = http.client.HTTPConnection(host, int(port_s), timeout=25.0)
+    try:
+        conn.request("GET", "/events",
+                     headers={"Authorization": f"Bearer {token}",
+                              API_VERSION_HEADER: API_VERSION})
+        resp = conn.getresponse()
+        assert resp.status == 200
+        assert "text/event-stream" in resp.getheader("Content-Type", "")
+        # spike's heartbeat is 15s; wait up to 22s.
+        deadline = time.monotonic() + 22.0
+        buf = b""
+        while time.monotonic() < deadline:
+            chunk = resp.read(1)
+            if not chunk:
+                break
+            buf += chunk
+            if b":" in buf and b"\n\n" in buf:
+                # SSE heartbeat is a comment line (`:\n\n` in spike).
+                break
+        # Heartbeat presence: spike emits `:\n\n`; our format used
+        # `:heartbeat ts\n\n`.  Accept either as a heartbeat marker.
+        assert (b":heartbeat" in buf) or (b":\n\n" in buf), \
+            f"no heartbeat in stream: {buf!r}"
+    finally:
+        conn.close()
+
+
+# ── daemon subcommands ─────────────────────────────────────────────────────
+
+def test_daemon_status_subcommand_when_running(daemon_proc):
+    _proc, home, _address, _token = daemon_proc
+    rc, stdout, stderr = _run_subcommand(["daemon", "status"], home)
+    assert rc == 0, f"stderr: {stderr}"
+    assert "transport:" in stdout
+    assert "address:" in stdout
+    assert "pong" in stdout
+
+
+def test_daemon_status_when_not_running(tmp_path):
+    rc, _stdout, stderr = _run_subcommand(["daemon", "status"], tmp_path)
+    assert rc == 1
+    assert "not running" in stderr.lower()
+
+
+def test_daemon_stop_clears_discovery(daemon_proc):
+    proc, home, _address, _token = daemon_proc
+    rc, _stdout, stderr = _run_subcommand(["daemon", "stop"], home)
+    assert rc == 0, f"stderr: {stderr}"
+    assert "stopped" in (_stdout + stderr).lower()
+    proc.wait(timeout=5)
+    assert not (home / ".cheetahclaws" / "daemon.json").exists()
+
+
+def test_daemon_logs_subcommand(daemon_proc):
+    _proc, home, _address, _token = daemon_proc
+    rc, stdout, _stderr = _run_subcommand(
+        ["daemon", "logs", "-n", "20"], home)
+    assert rc == 0
+    # Bootstrap emits structured JSON log lines under serve mode.
+    assert "bootstrap_done" in stdout or "daemon_listening" in stdout
+
+
+def test_daemon_rotate_token_changes_file(daemon_proc):
+    _proc, home, _address, token = daemon_proc
+    token_path = home / ".cheetahclaws" / "daemon_token"
+    rc, stdout, _stderr = _run_subcommand(["daemon", "rotate-token"], home)
+    assert rc == 0
+    assert "rotated" in stdout.lower()
+    assert token_path.read_text().strip() != token

--- a/tests/test_cc_daemon_discovery.py
+++ b/tests/test_cc_daemon_discovery.py
@@ -1,0 +1,160 @@
+"""Tests for cc_daemon/discovery.py — daemon.json read/write/locate."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import stat
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cc_daemon import discovery
+
+
+# ── make_info ──────────────────────────────────────────────────────────────
+
+def test_make_info_has_required_fields():
+    info = discovery.make_info(pid=1234, transport="unix",
+                                address="/tmp/x.sock", version="3.05.72")
+    for key in ("pid", "started_at", "transport", "address", "version", "schema"):
+        assert key in info
+    assert info["pid"] == 1234
+    assert info["transport"] == "unix"
+    assert info["address"] == "/tmp/x.sock"
+    assert info["version"] == "3.05.72"
+    assert info["schema"] == discovery.SCHEMA_VERSION
+
+
+def test_make_info_started_at_is_iso_utc():
+    info = discovery.make_info(pid=1, transport="tcp",
+                                address="127.0.0.1:8765", version="x")
+    # ISO 8601 UTC with Z suffix: "YYYY-MM-DDTHH:MM:SSZ"
+    assert info["started_at"].endswith("Z")
+    assert "T" in info["started_at"]
+
+
+# ── write / read ────────────────────────────────────────────────────────────
+
+def test_write_then_read_roundtrip(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    info = discovery.make_info(pid=1234, transport="unix",
+                                address="/x.sock", version="v")
+    discovery.write(info, path=p)
+    assert p.exists()
+    got = discovery.read(path=p)
+    assert got == info
+
+
+def test_read_missing_returns_none(tmp_path: Path):
+    p = tmp_path / "absent.json"
+    assert discovery.read(path=p) is None
+
+
+def test_read_corrupt_returns_none(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    p.write_text("{ this is not valid json")
+    assert discovery.read(path=p) is None
+
+
+def test_write_atomic_does_not_leave_partial_on_error(tmp_path: Path,
+                                                      monkeypatch):
+    p = tmp_path / "daemon.json"
+    p.write_text(json.dumps({"old": True}))
+
+    # Force os.replace to fail; the original file must remain intact.
+    real_replace = os.replace
+
+    def boom(_src, _dst):
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(os, "replace", boom)
+    info = discovery.make_info(pid=1, transport="tcp",
+                                address="127.0.0.1:1", version="v")
+    with pytest.raises(OSError):
+        discovery.write(info, path=p)
+
+    # Original survives, no .tmp leakage in stable name.
+    monkeypatch.setattr(os, "replace", real_replace)
+    assert json.loads(p.read_text()) == {"old": True}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_write_sets_mode_0600_on_posix(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    info = discovery.make_info(pid=1, transport="unix", address="/x", version="v")
+    discovery.write(info, path=p)
+    mode = stat.S_IMODE(os.stat(p).st_mode)
+    assert mode == 0o600
+
+
+# ── clear ──────────────────────────────────────────────────────────────────
+
+def test_clear_removes_file(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    p.write_text("{}")
+    discovery.clear(path=p)
+    assert not p.exists()
+
+
+def test_clear_idempotent_when_missing(tmp_path: Path):
+    p = tmp_path / "absent.json"
+    discovery.clear(path=p)  # must not raise
+
+
+# ── pid_alive ──────────────────────────────────────────────────────────────
+
+def test_pid_alive_self_returns_true():
+    assert discovery.pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_zero_or_negative_returns_false():
+    assert discovery.pid_alive(0) is False
+    assert discovery.pid_alive(-1) is False
+
+
+def test_pid_alive_unlikely_pid_returns_false():
+    # Pick a pid extremely unlikely to be running.  Loop down from 2**31
+    # in case any candidate happens to exist.
+    for candidate in (2**31 - 1, 2**31 - 2, 2**31 - 3):
+        if not discovery.pid_alive(candidate):
+            return
+    pytest.skip("no obviously-dead pid available on this system")
+
+
+# ── locate ─────────────────────────────────────────────────────────────────
+
+def test_locate_returns_none_when_no_file(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    assert discovery.locate(path=p) is None
+
+
+def test_locate_returns_info_when_pid_alive(tmp_path: Path):
+    p = tmp_path / "daemon.json"
+    info = discovery.make_info(pid=os.getpid(), transport="unix",
+                                address="/x", version="v")
+    discovery.write(info, path=p)
+    got = discovery.locate(path=p)
+    assert got is not None
+    assert got["pid"] == os.getpid()
+
+
+def test_locate_clears_stale_file_when_pid_dead(tmp_path: Path, monkeypatch):
+    p = tmp_path / "daemon.json"
+    info = discovery.make_info(pid=999999999, transport="tcp",
+                                address="127.0.0.1:1", version="v")
+    discovery.write(info, path=p)
+    monkeypatch.setattr(discovery, "pid_alive", lambda _pid: False)
+
+    assert discovery.locate(path=p) is None
+    assert not p.exists()  # stale file auto-cleared
+
+
+# ── default path ───────────────────────────────────────────────────────────
+
+def test_get_default_path_lives_under_config_dir():
+    from cc_config import CONFIG_DIR
+    p = discovery.get_default_path()
+    assert p == CONFIG_DIR / "daemon.json"

--- a/tests/test_cc_daemon_system_methods.py
+++ b/tests/test_cc_daemon_system_methods.py
@@ -1,0 +1,102 @@
+"""Tests for cc_daemon/system_methods.py — system.ping + system.shutdown."""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cc_daemon import system_methods
+from cc_daemon.rpc import CallContext, RpcRegistry
+
+
+# ── Fake DaemonState that exposes just the surface system_methods touches ──
+
+class _FakeState:
+    def __init__(self) -> None:
+        self.shutdown_event = threading.Event()
+        self.shutdown_calls = 0
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self.shutdown_event.set()
+
+
+def _ctx(client_id: str = "test-client") -> CallContext:
+    return CallContext(client_id=client_id, transport="tcp", api_version="0")
+
+
+def _call(registry: RpcRegistry, method: str, params=None,
+           ctx: CallContext = None) -> dict:
+    envelope = {"jsonrpc": "2.0", "id": 1, "method": method,
+                "params": params or {}}
+    response, _status = registry.dispatch(envelope, ctx or _ctx())
+    return response
+
+
+# ── system.ping ─────────────────────────────────────────────────────────────
+
+def test_system_ping_registers_and_returns_pong():
+    registry = RpcRegistry()
+    system_methods.register(registry, _FakeState())
+    response = _call(registry, "system.ping")
+    assert response["result"] == "pong"
+
+
+def test_system_ping_ignores_params():
+    registry = RpcRegistry()
+    system_methods.register(registry, _FakeState())
+    response = _call(registry, "system.ping", {"any": "thing"})
+    assert response["result"] == "pong"
+
+
+def test_system_ping_appears_in_method_list():
+    registry = RpcRegistry()
+    system_methods.register(registry, _FakeState())
+    methods = registry.methods()
+    assert "system.ping" in methods
+    assert "system.shutdown" in methods
+
+
+# ── system.shutdown ─────────────────────────────────────────────────────────
+
+def test_system_shutdown_triggers_state_shutdown():
+    state = _FakeState()
+    registry = RpcRegistry()
+    system_methods.register(registry, state)
+    response = _call(registry, "system.shutdown")
+    assert response["result"] == "shutdown_initiated"
+    assert state.shutdown_calls == 1
+    assert state.shutdown_event.is_set()
+
+
+def test_system_shutdown_returned_from_dispatch_with_correct_envelope():
+    state = _FakeState()
+    registry = RpcRegistry()
+    system_methods.register(registry, state)
+    envelope = {"jsonrpc": "2.0", "id": "abc", "method": "system.shutdown"}
+    response, status = registry.dispatch(envelope, _ctx())
+    assert status == 200
+    assert response == {"jsonrpc": "2.0", "id": "abc",
+                        "result": "shutdown_initiated"}
+
+
+# ── Coexistence with spike methods ──────────────────────────────────────────
+
+def test_register_does_not_clash_with_spike_methods():
+    """Spike's `register_methods` is invoked first by DaemonState.__init__;
+    system_methods.register must not collide with any spike-defined names."""
+    from cc_daemon.methods import register as register_spike
+    from cc_daemon.permission import PermissionStore
+
+    registry = RpcRegistry()
+    store = PermissionStore()
+    register_spike(registry, store)
+    state = _FakeState()
+    system_methods.register(registry, state)
+
+    methods = registry.methods()
+    assert "system.ping" in methods
+    assert "system.shutdown" in methods
+    assert "echo.ping" in methods  # spike survives

--- a/tests/test_daemon_cmd.py
+++ b/tests/test_daemon_cmd.py
@@ -1,0 +1,140 @@
+"""Tests for commands/daemon_cmd.py — `cheetahclaws daemon ...` subcommands.
+
+End-to-end behavior against a live daemon is covered in
+``tests/e2e_daemon_skeleton.py`` (F-1 task #10).  This file exercises the
+small behaviours that don't need a real daemon: dispatch routing, the
+"not running" branches, format helpers.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from commands import daemon_cmd
+
+
+# ── dispatch ───────────────────────────────────────────────────────────────
+
+def test_dispatch_empty_returns_usage(capsys):
+    rc = daemon_cmd.dispatch([])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "usage" in captured.err.lower()
+
+
+def test_dispatch_unknown_action(capsys):
+    rc = daemon_cmd.dispatch(["banana"])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "unknown" in captured.err.lower()
+
+
+# ── status when no daemon is running ───────────────────────────────────────
+
+def test_status_when_not_running(monkeypatch, capsys, tmp_path):
+    # Point discovery at an empty tmp file so locate() returns None.
+    p = tmp_path / "daemon.json"
+    monkeypatch.setattr(daemon_cmd._discovery, "get_default_path", lambda: p)
+    rc = daemon_cmd.dispatch(["status"])
+    assert rc == 1
+    assert "not running" in capsys.readouterr().err.lower()
+
+
+# ── stop when no daemon is running (idempotent) ────────────────────────────
+
+def test_stop_when_not_running_returns_zero(monkeypatch, tmp_path, capsys):
+    p = tmp_path / "daemon.json"
+    monkeypatch.setattr(daemon_cmd._discovery, "get_default_path", lambda: p)
+    rc = daemon_cmd.dispatch(["stop"])
+    assert rc == 0  # already in desired state
+    assert "not running" in capsys.readouterr().err.lower()
+
+
+# ── logs ───────────────────────────────────────────────────────────────────
+
+def test_logs_when_no_log_file(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(daemon_cmd, "_log_path", lambda: tmp_path / "absent.log")
+    rc = daemon_cmd.dispatch(["logs"])
+    assert rc == 0
+    assert "no log file" in capsys.readouterr().err.lower()
+
+
+def test_logs_tails_existing_file(monkeypatch, tmp_path, capsys):
+    log = tmp_path / "daemon.log"
+    log.write_text("\n".join(f"line{i}" for i in range(100)) + "\n")
+    monkeypatch.setattr(daemon_cmd, "_log_path", lambda: log)
+    rc = daemon_cmd.dispatch(["logs", "-n", "10"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    printed = [l for l in out.splitlines() if l.startswith("line")]
+    assert printed == [f"line{i}" for i in range(90, 100)]
+
+
+def test_logs_default_tail_is_50(monkeypatch, tmp_path, capsys):
+    log = tmp_path / "daemon.log"
+    log.write_text("\n".join(f"line{i}" for i in range(200)) + "\n")
+    monkeypatch.setattr(daemon_cmd, "_log_path", lambda: log)
+    daemon_cmd.dispatch(["logs"])
+    out = capsys.readouterr().out
+    printed = [l for l in out.splitlines() if l.startswith("line")]
+    assert len(printed) == 50
+    assert printed[0] == "line150"
+    assert printed[-1] == "line199"
+
+
+# ── rotate-token ───────────────────────────────────────────────────────────
+
+def test_rotate_token_writes_new_token(monkeypatch, tmp_path, capsys):
+    token_path = tmp_path / "token"
+    monkeypatch.setattr(daemon_cmd, "_default_token_path",
+                        lambda: token_path)
+    rc = daemon_cmd.dispatch(["rotate-token"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert token_path.exists()
+    assert token_path.read_text().strip() != ""
+    assert "rotated" in out.lower()
+
+
+def test_rotate_token_changes_value(monkeypatch, tmp_path):
+    token_path = tmp_path / "token"
+    monkeypatch.setattr(daemon_cmd, "_default_token_path",
+                        lambda: token_path)
+    daemon_cmd.dispatch(["rotate-token"])
+    first = token_path.read_text()
+    daemon_cmd.dispatch(["rotate-token"])
+    second = token_path.read_text()
+    assert first != second
+
+
+# ── format helpers ─────────────────────────────────────────────────────────
+
+def test_format_duration_seconds():
+    assert daemon_cmd._format_duration(5) == "5s"
+    assert daemon_cmd._format_duration(59.9) == "59s"
+
+
+def test_format_duration_minutes():
+    assert daemon_cmd._format_duration(60) == "1m 0s"
+    assert daemon_cmd._format_duration(125) == "2m 5s"
+
+
+def test_format_duration_hours():
+    assert daemon_cmd._format_duration(3700) == "1h 1m 40s"
+
+
+def test_seconds_since_handles_recent_iso():
+    import datetime as dt
+    now = dt.datetime.now(dt.timezone.utc)
+    iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    out = daemon_cmd._seconds_since(iso)
+    assert out is not None
+    assert 0.0 <= out < 5.0
+
+
+def test_seconds_since_returns_none_for_garbage():
+    assert daemon_cmd._seconds_since("not a date") is None

--- a/tests/test_health_payloads.py
+++ b/tests/test_health_payloads.py
@@ -1,0 +1,72 @@
+"""Tests for health.py module-level payload helpers.
+
+These are exercised by both health.py's own HTTP server and by the daemon
+listener (daemon/server.py).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import health
+
+
+def test_healthz_payload_basic_shape():
+    body = health.healthz_payload({"model": "claude-x"})
+    assert body["status"] == "ok"
+    assert body["model"] == "claude-x"
+    assert "uptime_s" in body
+    assert isinstance(body["active_sessions"], int)
+
+
+def test_healthz_payload_handles_missing_config():
+    body = health.healthz_payload(None)
+    assert body["status"] == "ok"
+    assert body["model"] == ""
+
+
+def test_readyz_ok_when_no_open_circuits(monkeypatch):
+    monkeypatch.setattr(health, "_circuit_states", lambda: {})
+    body = health.readyz_payload({"model": "m"})
+    assert body["status"] == "ok"
+    assert body["circuits"] == {}
+    assert "open_circuits" not in body
+
+
+def test_readyz_degraded_when_a_circuit_is_open(monkeypatch):
+    monkeypatch.setattr(health, "_circuit_states",
+                        lambda: {"anthropic": "open", "openai": "closed"})
+    body = health.readyz_payload({})
+    assert body["status"] == "degraded"
+    assert body["open_circuits"] == ["anthropic"]
+
+
+def test_metrics_payload_includes_uptime_and_circuits(monkeypatch):
+    monkeypatch.setattr(health, "_circuit_states",
+                        lambda: {"x": "closed"})
+    body = health.metrics_payload({"model": "m"})
+    for key in ("uptime_s", "model", "active_sessions",
+                 "circuits", "daily_tokens", "daily_cost_usd"):
+        assert key in body
+    assert body["circuits"] == {"x": "closed"}
+
+
+def test_payload_for_dispatches_correct_keys(monkeypatch):
+    monkeypatch.setattr(health, "_circuit_states", lambda: {})
+    assert health.payload_for("/healthz", {"model": "x"})["status"] == "ok"
+    assert health.payload_for("/readyz", {"model": "x"})["status"] == "ok"
+    assert "daily_tokens" in health.payload_for("/metrics", {"model": "x"})
+
+
+def test_payload_for_unknown_path_returns_empty():
+    assert health.payload_for("/nope") == {}
+
+
+def test_install_config_pins_module_default():
+    health.install_config({"model": "pinned"})
+    body = health.healthz_payload(None)
+    assert body["model"] == "pinned"


### PR DESCRIPTION
Foundation PR for [#68](https://github.com/SafeRL-Lab/cheetahclaws/issues/68) and follow-up to the [RFC 0001 design note](https://github.com/SafeRL-Lab/cheetahclaws/pull/74). Builds on @chauncygu's spike branch [`feature/daemon-spike`](https://github.com/SafeRL-Lab/cheetahclaws/tree/feature/daemon-spike) — thanks for the reference scaffolding, it saved a lot of contract-design churn.

This PR is **F-1 in the 9-PR roadmap** captured in `docs/RFC/0002-daemon-foundation-roadmap.md`. No service migration yet — that's F-2 through F-8. The deliverable here is a runnable `cheetahclaws serve` plus the `cheetahclaws daemon {status, stop, logs, rotate-token}` control surface, layered on top of the spike's contract code.

**Calling this out up front: I'd really like a sanity-check on the implementation approach before we build F-2/F-3 on top of it.** Specifically — does keeping spike's `server.py / auth.py / originator.py / rpc.py` as the contract source of truth, and adding glue alongside (discovery, system methods, daemon CLI, health wiring), match what you had in mind in [#68](https://github.com/SafeRL-Lab/cheetahclaws/issues/68)? If you'd rather see the spike modules absorbed into a different shape, I'd want to know now rather than after F-3 is in flight.

## What's in this PR

### Spike modules — kept as-is

These encode the wire contract you reviewed in #74; not touched:

`cc_daemon/__init__.py`, `auth.py`, `events.py`, `methods.py`, `originator.py`, `permission.py`, `rpc.py`, `spike_client.py`, `tests/test_daemon_spike.py` (13 cases, all green)

### Spike modules — patched (minimal, not rewrites)

- `cc_daemon/server.py` (+75 / −29) — Windows guard around `socketserver.UnixStreamServer`; `DaemonState` gains `unauthenticated_metrics` and `config` keyword-only kwargs (defaults preserve spike behavior); registers `system_methods` alongside `register_methods`; `/healthz` `/readyz` `/metrics` route through `health.payload_for(path, config)`.
- `cc_daemon/cli.py` (+176 / −118) — rewritten to expose `serve_main(argv)` for the new `cheetahclaws serve` surface. **Legacy `python -m cc_daemon.cli {serve|status|stop|logs|rotate-token}` entry preserved** so the spike-notes commands keep working.

### Foundation glue — new files

- `cc_daemon/discovery.py` (175) — atomic write of `~/.cheetahclaws/daemon.json` (pid, transport, address, schema). Cross-platform `pid_alive()` + stale-file auto-clear. Spike's pid file says "is anything running?"; discovery says "where is it?" so REPL/Web/bridge clients can find the daemon without parsing CLI args.
- `cc_daemon/system_methods.py` (44) — registers `system.ping` (RFC contract name; coexists with spike's `echo.ping`) and `system.shutdown` (sets `DaemonState.shutdown_event`). The latter is the only cross-platform graceful-exit channel — Windows can't deliver SIGTERM cleanly to another Python process.
- `commands/daemon_cmd.py` (306) — `cheetahclaws daemon {status, stop, logs, rotate-token}`. `status` reads discovery + pings `system.ping`; `stop` calls `system.shutdown` RPC then falls back to SIGTERM / `TerminateProcess`; `logs` tails `~/.cheetahclaws/logs/daemon.log`; `rotate-token` regenerates the token file. RPC client sends `Cheetahclaws-Api-Version: 0` on every call.
- `cheetahclaws.py` (+10) — `main()` short-circuit for `serve` / `daemon` verbs, plus backward-compat alias for `cheetahclaws spike-daemon ...`.
- `health.py` (refactored) — extracted module-level `healthz_payload(config)` / `readyz_payload(config)` / `metrics_payload(config)` / `payload_for(path, config)` so both the existing standalone health server (started by `bootstrap()` when `health_check_port` is set) and the daemon listener reuse the same circuit-breaker / quota / runtime-registry probes. Existing `health_check_port` users see no behavior change.
- `docs/RFC/0002-daemon-foundation-roadmap.md` — F-1 through F-9 PR breakdown with per-PR scope and acceptance criteria.
- `docs/architecture.md` — Daemon section pointing at `cc_daemon` modules and the foundation glue.

### Tests — 72 new + 13 spike, all green

- `tests/test_cc_daemon_discovery.py` (16)
- `tests/test_cc_daemon_system_methods.py` (8)
- `tests/test_daemon_cmd.py` (14)
- `tests/test_health_payloads.py` (8)
- `tests/e2e_daemon_skeleton.py` (13) — **subprocess** boundary tests: real `cheetahclaws serve` boot under isolated `$HOME`, exercises discovery / RPC / auth / SSE heartbeat / all `daemon` subcommands.
- `tests/test_daemon_spike.py` (13, untouched) — your contract validation suite still passes.

`pytest tests/ -q` → **623 passed, 3 skipped, 0 failed** (3 skips are POSIX-only tests on the Windows dev machine; one pre-existing GBK encoding failure in `test_input_completer.py` is unrelated to this PR — it fails on `upstream/main` too).

## Behavior change worth flagging

**`/healthz`, `/readyz`, `/metrics` are now auth-gated by default**, per [RFC 0001 §3](https://github.com/SafeRL-Lab/cheetahclaws/blob/main/docs/RFC/0001-daemon-design-note.md). Spike returned them unauthenticated; the foundation routes them through `health.payload_for(...)` and requires `Authorization: Bearer <token>` (or a matching UID on the Unix socket). Prometheus / external scrapers opt out via `cheetahclaws serve --unauthenticated-metrics`. No spike test was checking the unauthenticated-by-default behavior, so nothing breaks in the existing suite — but I want this called out so it's not a surprise later.

## What is NOT in F-1 (intentional)

Per the roadmap:

- **`agent.run` integration / real `session.send`** — F-3+
- **Bridges in daemon** (Telegram / Slack / WeChat) — F-6 / F-7 / F-8
- **`monitor/scheduler` in daemon** — F-3
- **`agent_runner` subprocess-per-agent** — F-4
- **SQLite event persistence** (replacing the spike's in-memory ring) — F-2
- **Cost guardrail conservative defaults** under `serve` — F-9
- **macOS peer-cred** — left as `TODO(macos)` in `cc_daemon/auth.py` exactly where the spike left it; happy to fill it in a follow-up if you'd prefer

End-user note: F-1 alone gives end users no new feature — `cheetahclaws serve` boots a daemon, but no actual service runs inside it yet. The audience for this PR is contract reviewers and future PR authors building F-2..F-9 on top.

## Compatibility

- `python -m cc_daemon.cli {serve|status|stop|logs|rotate-token} ...` — preserved (delegates to `serve_main` / `commands.daemon_cmd.dispatch`).
- `cheetahclaws spike-daemon ...` — preserved as alias for the same code path, so the example commands in `docs/RFC/0001-spike-notes.md` keep working unchanged.
- `cheetahclaws serve` / `cheetahclaws daemon <action>` — the new canonical surface.

## Questions for review

1. **Implementation approach** — is the spike-as-contract + glue-on-top split the shape you wanted? Especially: was rewriting `cli.py` (vs. leaving it as `spike-daemon` and adding parallel `serve` entry) the right call?
2. **Auth-by-default for `/metrics`** — accept this aligns with RFC 0001 §3, or push back?
3. **macOS peer-cred** — fold a `getpeereid()` `ctypes` implementation into this PR, or keep the spike's `TODO(macos)` and address in a follow-up?
4. Anything in the foundation roadmap you'd reorder before F-2 starts?

Refs #68, #74
