### PR TITLE
feat(mcp): HTTP/SSE transport, OAuth 2.0 PKCE, env config                                                                                                                                                              

### DIFF
--- a/cc_config.py
+++ b/cc_config.py
@@ -86,6 +86,8 @@ def load_config() -> dict:
     # Also accept ANTHROPIC_API_KEY env for backward-compat
     if not cfg.get("anthropic_api_key"):
         cfg["anthropic_api_key"] = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not cfg.get("anthropic_endpoint"):
+        cfg["anthropic_endpoint"] = os.environ.get("ANTHROPIC_ENDPOINT", "https://api.anthropic.com")
     return cfg
 
 

--- a/cc_config.py
+++ b/cc_config.py
@@ -86,8 +86,11 @@ def load_config() -> dict:
     # Also accept ANTHROPIC_API_KEY env for backward-compat
     if not cfg.get("anthropic_api_key"):
         cfg["anthropic_api_key"] = os.environ.get("ANTHROPIC_API_KEY", "")
-    if not cfg.get("anthropic_endpoint"):
-        cfg["anthropic_endpoint"] = os.environ.get("ANTHROPIC_ENDPOINT", "https://api.anthropic.com")
+    # Env var always wins over persisted value so .env changes take effect immediately
+    if os.environ.get("ANTHROPIC_ENDPOINT"):
+        cfg["anthropic_endpoint"] = os.environ["ANTHROPIC_ENDPOINT"]
+    elif not cfg.get("anthropic_endpoint"):
+        cfg["anthropic_endpoint"] = "https://api.anthropic.com"
     return cfg
 
 

--- a/cc_mcp/client.py
+++ b/cc_mcp/client.py
@@ -136,6 +136,8 @@ class HttpTransport:
 
     For SSE servers: sends messages via POST to the SSE session endpoint.
     For HTTP servers: sends messages via POST and reads response directly.
+    Supports OAuth 2.0 PKCE: when the server returns 401, an OAuthSession is
+    created automatically to obtain and refresh Bearer tokens.
     """
 
     def __init__(self, config: MCPServerConfig):
@@ -147,13 +149,18 @@ class HttpTransport:
         self._sse_thread: Optional[threading.Thread] = None
         self._sse_pending: Dict[int, dict] = {}
         self._running = False
+        self._oauth: Optional[Any] = None  # OAuthSession, created on first 401
 
     def _get_client(self):
         if self._client is None:
             try:
                 import httpx
+                # Accept both JSON and SSE — required by servers like sap-jira
+                # that return 406 when only one content type is advertised.
+                headers = {"Accept": "application/json, text/event-stream",
+                           **self._config.headers}
                 self._client = httpx.Client(
-                    headers=self._config.headers,
+                    headers=headers,
                     timeout=self._config.timeout,
                     follow_redirects=True,
                 )
@@ -161,13 +168,47 @@ class HttpTransport:
                 raise RuntimeError("httpx is required for HTTP/SSE MCP transport: pip install httpx")
         return self._client
 
+    def _ensure_oauth(self) -> None:
+        """Initialise OAuthSession on first 401 and inject the token into the client."""
+        if self._oauth is None:
+            from cc_mcp.oauth import OAuthSession
+            # Pass any non-auth headers already configured (e.g. custom SAP headers)
+            extra = {k: v for k, v in self._config.headers.items()
+                     if not k.lower().startswith("authorization")}
+            self._oauth = OAuthSession(self._config.name, self._config.url, extra)
+        token = self._oauth.get_token()
+        # Rebuild the httpx client with the fresh token injected.
+        if self._client:
+            self._client.close()
+            self._client = None
+        import httpx
+        headers = {"Accept": "application/json, text/event-stream",
+                   **self._config.headers, "Authorization": f"Bearer {token}"}
+        self._client = httpx.Client(
+            headers=headers,
+            timeout=self._config.timeout,
+            follow_redirects=True,
+        )
+
     def start(self) -> None:
         """For SSE transport: connect to the /sse endpoint and get session URL."""
         if self._config.transport == MCPTransport.SSE:
             self._start_sse()
         else:
-            # Pure HTTP: no persistent connection needed
+            # Streamable HTTP: no persistent connection needed; probe for 401.
             self._session_url = self._config.url
+            self._probe_oauth()
+
+    def _probe_oauth(self) -> None:
+        """HEAD the resource URL; if 401, run OAuth flow before first request."""
+        import httpx
+        try:
+            r = httpx.get(self._config.url, headers=self._config.headers,
+                          timeout=5, follow_redirects=True)
+            if r.status_code == 401:
+                self._ensure_oauth()
+        except Exception:
+            pass  # network errors surface properly during request()
 
     def _start_sse(self) -> None:
         """Open SSE stream to get session endpoint, then start background reader."""
@@ -239,10 +280,27 @@ class HttpTransport:
             self._sse_pending.pop(req_id, None)
             result = holder["result"]
         else:
-            # For HTTP: POST and get response directly
-            resp = client.post(self._session_url or self._config.url, json=msg, timeout=wait_secs)
-            resp.raise_for_status()
-            result = resp.json()
+            # Streamable HTTP: POST returns an SSE stream; read first data: line.
+            # Retry once on 401 (token expired mid-session).
+            url = self._session_url or self._config.url
+            result = None
+            for _attempt in range(2):
+                with client.stream("POST", url, json=msg, timeout=wait_secs) as resp:
+                    if resp.status_code == 401 and _attempt == 0:
+                        resp.read()  # drain
+                        self._ensure_oauth()
+                        client = self._get_client()
+                        continue
+                    resp.raise_for_status()
+                    ct = resp.headers.get("content-type", "")
+                    if "text/event-stream" in ct:
+                        for line in resp.iter_lines():
+                            if line.startswith("data:"):
+                                result = json.loads(line[5:].strip())
+                                break
+                    else:
+                        result = resp.json()
+                    break  # success
 
         if result is None:
             raise TimeoutError(f"MCP server '{self._config.name}' timed out on '{method}'")
@@ -446,15 +504,21 @@ class MCPManager:
     def __init__(self):
         self._clients: Dict[str, MCPClient] = {}
 
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        """Normalize a server name to match the qualified tool name format."""
+        return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
+
     def add_server(self, config: MCPServerConfig) -> MCPClient:
         """Register a server. Replaces any existing client with the same name."""
-        if config.name in self._clients:
+        key = self._sanitize_name(config.name)
+        if key in self._clients:
             try:
-                self._clients[config.name].disconnect()
+                self._clients[key].disconnect()
             except Exception:
                 pass
         client = MCPClient(config)
-        self._clients[config.name] = client
+        self._clients[key] = client
         return client
 
     def connect_all(self) -> Dict[str, Optional[str]]:
@@ -474,7 +538,7 @@ class MCPManager:
 
     def connect_server(self, name: str) -> MCPClient:
         """Connect (or reconnect) a single server by name."""
-        client = self._clients.get(name)
+        client = self._clients.get(self._sanitize_name(name))
         if client is None:
             raise KeyError(f"MCP server '{name}' not configured")
         if client.state != MCPServerState.CONNECTED:
@@ -528,7 +592,7 @@ class MCPManager:
                 pass
 
     def reload_server(self, name: str) -> None:
-        client = self._clients.get(name)
+        client = self._clients.get(self._sanitize_name(name))
         if client:
             client.reconnect()
             client.list_tools()

--- a/cc_mcp/oauth.py
+++ b/cc_mcp/oauth.py
@@ -1,0 +1,338 @@
+"""OAuth 2.0 PKCE flow for MCP HTTP servers.
+
+Implements the MCP Authorization spec:
+  - Resource server metadata discovery (RFC 9728)
+  - Authorization server metadata discovery (RFC 8414)
+  - Dynamic client registration (RFC 7591) — used when no client_id configured
+  - Authorization code + PKCE (S256) flow
+  - Token refresh
+  - Token persistence to ~/.cheetahclaws/mcp_oauth.json
+
+Usage (from HttpTransport):
+    from cc_mcp.oauth import OAuthSession
+    session = OAuthSession(server_name, resource_url, headers_config)
+    token = session.get_token()   # blocks for browser auth on first call
+    # then inject:  {"Authorization": f"Bearer {token}"}
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import threading
+import time
+import urllib.parse
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+_TOKEN_STORE = Path.home() / ".cheetahclaws" / "mcp_oauth.json"
+
+
+# ── Token persistence ─────────────────────────────────────────────────────────
+
+def _load_store() -> dict:
+    try:
+        return json.loads(_TOKEN_STORE.read_text())
+    except Exception:
+        return {}
+
+
+def _save_store(data: dict) -> None:
+    _TOKEN_STORE.parent.mkdir(parents=True, exist_ok=True)
+    _TOKEN_STORE.write_text(json.dumps(data, indent=2))
+
+
+# ── PKCE helpers ──────────────────────────────────────────────────────────────
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+# ── OAuth metadata discovery ──────────────────────────────────────────────────
+
+def _discover(resource_url: str, extra_headers: dict) -> dict:
+    """Return authorization server metadata for the given MCP resource URL.
+
+    Steps (per MCP spec):
+      1. Fetch /.well-known/oauth-protected-resource[/<path>]
+      2. Pick the first authorization_server from the response
+      3. Fetch that server's /.well-known/oauth-authorization-server
+    """
+    import httpx
+    parsed = urllib.parse.urlparse(resource_url)
+    path_suffix = parsed.path.lstrip("/")
+    well_known_candidates = []
+    if path_suffix:
+        well_known_candidates.append(
+            f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-protected-resource/{path_suffix}"
+        )
+    well_known_candidates.append(
+        f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-protected-resource"
+    )
+
+    resource_meta = None
+    for url in well_known_candidates:
+        try:
+            r = httpx.get(url, headers=extra_headers, timeout=10, follow_redirects=True)
+            if r.status_code == 200:
+                resource_meta = r.json()
+                break
+        except Exception:
+            continue
+
+    if not resource_meta:
+        raise RuntimeError(f"Could not discover OAuth metadata for {resource_url}")
+
+    auth_servers = resource_meta.get("authorization_servers", [])
+    if not auth_servers:
+        raise RuntimeError(f"No authorization_servers in OAuth metadata for {resource_url}")
+
+    as_base = auth_servers[0].rstrip("/")
+    as_meta_url = f"{as_base}/.well-known/oauth-authorization-server"
+    r = httpx.get(as_meta_url, timeout=10, follow_redirects=True)
+    if r.status_code != 200:
+        raise RuntimeError(f"Failed to fetch authorization server metadata from {as_meta_url}: {r.status_code}")
+    return r.json()
+
+
+# ── Dynamic client registration ───────────────────────────────────────────────
+
+def _register_client(registration_endpoint: str, server_name: str, redirect_uri: str) -> str:
+    """Register a new OAuth client and return the client_id."""
+    import httpx
+    payload = {
+        "client_name": f"cheetahclaws-{server_name}",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+    r = httpx.post(registration_endpoint, json=payload, timeout=10)
+    r.raise_for_status()
+    return r.json()["client_id"]
+
+
+# ── Local callback server ─────────────────────────────────────────────────────
+
+class _CallbackServer:
+    """Tiny HTTP server that catches the OAuth redirect and extracts the code."""
+
+    def __init__(self, port: int, state: str):
+        self._port = port
+        self._state = state
+        self._code: Optional[str] = None
+        self._error: Optional[str] = None
+        self._event = threading.Event()
+        self._server: Optional[http.server.HTTPServer] = None
+
+    def start(self) -> None:
+        parent = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                parsed = urllib.parse.urlparse(self.path)
+                params = urllib.parse.parse_qs(parsed.query)
+                if params.get("state", [""])[0] != parent._state:
+                    parent._error = "state mismatch"
+                elif "error" in params:
+                    parent._error = params["error"][0]
+                else:
+                    parent._code = params.get("code", [None])[0]
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                msg = "Authorization complete. You can close this tab." \
+                    if parent._code else f"Authorization failed: {parent._error}"
+                self.wfile.write(f"<html><body><p>{msg}</p></body></html>".encode())
+                parent._event.set()
+
+            def log_message(self, *_):
+                pass  # silence request logs
+
+        self._server = http.server.HTTPServer(("127.0.0.1", self._port), Handler)
+        t = threading.Thread(target=self._server.serve_forever, daemon=True)
+        t.start()
+
+    def wait(self, timeout: int = 120) -> Optional[str]:
+        self._event.wait(timeout=timeout)
+        if self._server:
+            self._server.shutdown()
+        if self._error:
+            raise RuntimeError(f"OAuth error: {self._error}")
+        return self._code
+
+
+# ── Token exchange & refresh ──────────────────────────────────────────────────
+
+def _exchange_code(token_endpoint: str, client_id: str, code: str,
+                   redirect_uri: str, verifier: str) -> dict:
+    import httpx
+    r = httpx.post(token_endpoint, data={
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": verifier,
+    }, timeout=15)
+    r.raise_for_status()
+    return r.json()
+
+
+def _refresh_token(token_endpoint: str, client_id: str, refresh: str) -> dict:
+    import httpx
+    r = httpx.post(token_endpoint, data={
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": client_id,
+    }, timeout=15)
+    r.raise_for_status()
+    return r.json()
+
+
+# ── OAuthSession ──────────────────────────────────────────────────────────────
+
+class OAuthSession:
+    """Manages the full OAuth lifecycle for one MCP server.
+
+    Call get_token() before each request. It returns a valid access token,
+    refreshing or re-authorizing transparently as needed.
+    """
+
+    def __init__(self, server_name: str, resource_url: str,
+                 extra_headers: dict | None = None):
+        self._name = server_name
+        self._resource_url = resource_url
+        self._extra_headers = extra_headers or {}
+        self._lock = threading.Lock()
+        self._as_meta: Optional[dict] = None   # cached auth server metadata
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def get_token(self) -> str:
+        """Return a valid access token, refreshing or re-authorizing as needed."""
+        with self._lock:
+            store = _load_store()
+            entry = store.get(self._name, {})
+
+            # Valid non-expired token
+            if entry.get("access_token") and not self._is_expired(entry):
+                return entry["access_token"]
+
+            # Try refresh first
+            if entry.get("refresh_token"):
+                try:
+                    meta = self._as_metadata()
+                    tokens = _refresh_token(
+                        meta["token_endpoint"],
+                        entry["client_id"],
+                        entry["refresh_token"],
+                    )
+                    entry = self._merge_tokens(entry, tokens)
+                    store[self._name] = entry
+                    _save_store(store)
+                    return entry["access_token"]
+                except Exception:
+                    pass  # fall through to full re-auth
+
+            # Full interactive auth
+            entry = self._authorize(entry)
+            store[self._name] = entry
+            _save_store(store)
+            return entry["access_token"]
+
+    def clear(self) -> None:
+        """Remove stored tokens (force re-auth on next get_token())."""
+        store = _load_store()
+        store.pop(self._name, None)
+        _save_store(store)
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _as_metadata(self) -> dict:
+        if self._as_meta is None:
+            self._as_meta = _discover(self._resource_url, self._extra_headers)
+        return self._as_meta
+
+    @staticmethod
+    def _is_expired(entry: dict) -> bool:
+        exp = entry.get("expires_at")
+        if exp is None:
+            return False
+        # Refresh 60 s before actual expiry
+        return time.time() >= exp - 60
+
+    @staticmethod
+    def _merge_tokens(entry: dict, tokens: dict) -> dict:
+        entry["access_token"] = tokens["access_token"]
+        if "refresh_token" in tokens:
+            entry["refresh_token"] = tokens["refresh_token"]
+        if "expires_in" in tokens:
+            entry["expires_at"] = time.time() + int(tokens["expires_in"])
+        else:
+            entry.pop("expires_at", None)
+        return entry
+
+    def _authorize(self, entry: dict) -> dict:
+        meta = self._as_metadata()
+        auth_endpoint  = meta["authorization_endpoint"]
+        token_endpoint = meta["token_endpoint"]
+        reg_endpoint   = meta.get("registration_endpoint")
+
+        # Ensure we have a client_id (register if not)
+        client_id = entry.get("client_id")
+        if not client_id and reg_endpoint:
+            port = self._pick_port()
+            redirect_uri = f"http://localhost:{port}/callback"
+            client_id = _register_client(reg_endpoint, self._name, redirect_uri)
+            entry["client_id"] = client_id
+        elif not client_id:
+            raise RuntimeError(
+                f"MCP server '{self._name}' requires OAuth but has no client_id "
+                "and does not support dynamic registration. "
+                "Add 'oauth_client_id' to its mcp.json entry."
+            )
+
+        port = self._pick_port()
+        redirect_uri = f"http://localhost:{port}/callback"
+        verifier, challenge = _pkce_pair()
+        state = secrets.token_urlsafe(32)
+
+        params = urllib.parse.urlencode({
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "scope": "mcp",
+        })
+        auth_url = f"{auth_endpoint}?{params}"
+
+        cb = _CallbackServer(port, state)
+        cb.start()
+
+        print(f"\n🔐 OAuth required for MCP server '{self._name}'")
+        print(f"   Opening browser… if it doesn't open, visit:\n   {auth_url}\n")
+        webbrowser.open(auth_url)
+
+        code = cb.wait(timeout=120)
+        if not code:
+            raise RuntimeError(f"OAuth timed out waiting for callback for '{self._name}'")
+
+        tokens = _exchange_code(token_endpoint, client_id, code, redirect_uri, verifier)
+        entry["client_id"] = client_id
+        return self._merge_tokens(entry, tokens)
+
+    @staticmethod
+    def _pick_port() -> int:
+        import socket
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]

--- a/cc_mcp/types.py
+++ b/cc_mcp/types.py
@@ -1,6 +1,7 @@
 """MCP type definitions: server configs, tool descriptors, connection state."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -55,7 +56,7 @@ class MCPServerConfig:
             args=d.get("args", []),
             env=d.get("env", {}),
             url=d.get("url", ""),
-            headers=d.get("headers", {}),
+            headers={k: os.path.expandvars(v) for k, v in d.get("headers", {}).items()},
             timeout=int(d.get("timeout", 30)),
             disabled=bool(d.get("disabled", False)),
         )

--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -113,6 +113,24 @@ from __future__ import annotations
 
 # ── Standard library ───────────────────────────────────────────────────────
 import os
+
+# Load .env before any other imports read os.environ
+def _load_env() -> None:
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    if not os.path.exists(env_path):
+        return
+    with open(env_path) as _f:
+        for _line in _f:
+            _line = _line.strip()
+            if not _line or _line.startswith("#") or "=" not in _line:
+                continue
+            _k, _, _v = _line.partition("=")
+            _v = _v.strip()
+            if len(_v) >= 2 and _v[0] in ('"', "'") and _v[-1] == _v[0]:
+                _v = _v[1:-1]
+            os.environ.setdefault(_k.strip(), _v)
+_load_env()
+
 import re
 import sys
 import uuid
@@ -499,7 +517,7 @@ _CMD_META: dict[str, tuple[str, list[str]]] = {
     "skills":      ("List available skills",              []),
     "memory":      ("Search / list / consolidate memories", ["consolidate"]),
     "agents":      ("Show background agents",             []),
-    "mcp":         ("Manage MCP servers",                 ["reload", "add", "remove"]),
+    "mcp":         ("Manage MCP servers",                 ["reload", "add", "remove", "list"]),
     "plugin":      ("Manage plugins",                     ["install", "uninstall", "enable",
                                                            "disable", "disable-all", "update",
                                                            "recommend", "info"]),

--- a/commands/advanced.py
+++ b/commands/advanced.py
@@ -845,8 +845,25 @@ def cmd_mcp(args: str, _state, config) -> bool:
         return True
 
     if subcmd == "add":
+        # HTTP/SSE transport: /mcp add <name> --transport http <url>
+        if "--transport" in parts:
+            ti = parts.index("--transport")
+            if ti + 2 >= len(parts):
+                err("Usage: /mcp add <name> --transport http <url>")
+                return True
+            transport_type = parts[ti + 1].lower()
+            if transport_type not in ("http", "sse"):
+                err(f"Unsupported transport '{transport_type}'. Use: http, sse")
+                return True
+            name = parts[1]
+            url = parts[ti + 2]
+            add_server_to_user_config(name, {"type": transport_type, "url": url})
+            ok(f"Added MCP server '{name}' ({transport_type}: {url}) → /mcp reload to connect")
+            return True
+        # Stdio: /mcp add <name> <command> [args...]
         if len(parts) < 3:
-            err("Usage: /mcp add <name> <command> [arg1 arg2 ...]")
+            err("Usage: /mcp add <name> <command> [arg1 arg2 ...]\n"
+                "       /mcp add <name> --transport http <url>")
             return True
         name = parts[1]
         command = parts[2]
@@ -868,6 +885,10 @@ def cmd_mcp(args: str, _state, config) -> bool:
             ok(f"Removed MCP server '{name}' from user config")
         else:
             err(f"Server '{name}' not found in user config")
+        return True
+
+    if subcmd not in ("", "list"):
+        err(f"Unknown /mcp subcommand '{subcmd}'. Use: reload, add, remove, list")
         return True
 
     mgr = get_mcp_manager()
@@ -897,7 +918,10 @@ def cmd_mcp(args: str, _state, config) -> bool:
         }.get(client.state.value, "dim")
         print(f"  {clr(client.status_line(), status_color)}")
         for tool in client._tools:
-            print(f"      {clr(tool.qualified_name, 'cyan')}  {tool.description[:60]}")
+            import textwrap
+            desc_lines = textwrap.wrap(tool.description, width=72, subsequent_indent=" " * 8)
+            desc = ("\n" + " " * 8).join(desc_lines) if desc_lines else ""
+            print(f"      {clr(tool.qualified_name, 'cyan')}  {desc}")
             total_tools += 1
 
     if total_tools:

--- a/commands/core.py
+++ b/commands/core.py
@@ -331,8 +331,9 @@ def cmd_doctor(args: str, state, config) -> bool:
             ptype = prov.get("type", "openai")
 
             if ptype == "anthropic":
+                _ant_base = config.get("anthropic_endpoint", "https://api.anthropic.com").rstrip("/")
                 req = urllib.request.Request(
-                    "https://api.anthropic.com/v1/messages",
+                    f"{_ant_base}/v1/messages",
                     data=json.dumps({
                         "model": model,
                         "max_tokens": 1,
@@ -587,8 +588,9 @@ def run_setup_wizard(config: dict) -> None:
             urllib.request.urlopen(f"{base_url}/api/tags", timeout=5)
             ok("Ollama: connected!")
         elif chosen_pname == "anthropic" and existing_key:
+            _ant_base = config.get("anthropic_endpoint", "https://api.anthropic.com").rstrip("/")
             req = urllib.request.Request(
-                "https://api.anthropic.com/v1/messages",
+                f"{_ant_base}/v1/messages",
                 data=json.dumps({"model": config["model"], "max_tokens": 1,
                                  "messages": [{"role": "user", "content": "hi"}]}).encode(),
                 headers={"x-api-key": existing_key, "anthropic-version": "2023-06-01",

--- a/providers.py
+++ b/providers.py
@@ -512,7 +512,8 @@ def stream_anthropic(
 ) -> Generator:
     """Stream from Anthropic API. Yields TextChunk/ThinkingChunk, then AssistantTurn."""
     import anthropic as _ant
-    client = _ant.Anthropic(api_key=api_key)
+    base_url = config.get("anthropic_endpoint") or "https://api.anthropic.com"
+    client = _ant.Anthropic(api_key=api_key, base_url=base_url)
 
     _mt = resolve_max_tokens(config, "anthropic", model) or 8192
     kwargs = {


### PR DESCRIPTION
  - Adds full HTTP and SSE transport support to the MCP client, including Streamable HTTP (POST → SSE response) used by servers like github-tools                    
  - Implements OAuth 2.0 PKCE flow for HTTP MCP servers (sap-jira): dynamic client registration, browser redirect, token persistence to                              
  ~/.cheetahclaws/mcp_oauth.json, and transparent refresh                                                                                                            
  - Restores .env loader at startup and adds ANTHROPIC_ENDPOINT override so a corporate proxy can replace api.anthropic.com; env var now always wins over stale
  persisted config                                                                                                                                                   
  - Fixes $ENV_VAR expansion in MCP HTTP header configs and server name sanitization so hyphenated names (github-tools) resolve correctly when tools are invoked
  - Extends /mcp add with --type http/sse flags and adds /mcp list subcommand