### PR TITLE
feat(ui): add /theme slash command with 15 console color presets

### DIFF
--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -240,6 +240,9 @@ from commands.monitor_cmd import cmd_subscribe, cmd_subscriptions, cmd_unsubscri
 
 from commands.research_cmd import cmd_research, cmd_reports
 
+# ── Theme command ──────────────────────────────────────────────────────────
+from commands.theme_cmd import cmd_theme
+
 # ── Tools / thread-local bridge state ─────────────────────────────────────
 from tools import (
     ask_input_interactive,
@@ -415,6 +418,7 @@ COMMANDS = {
     "circuit":     cmd_circuit,
     "web":         cmd_web,
     "setup":       lambda a, s, c: (run_setup_wizard(c), True)[1],
+    "theme":       cmd_theme,
     "exit":        cmd_exit,
     "quit":        cmd_exit,
     "resume":      cmd_resume,
@@ -551,6 +555,7 @@ _CMD_META: dict[str, tuple[str, list[str]]] = {
     "circuit":     ("Show / reset per-provider circuit breakers", ["status", "reset"]),
     "web":         ("Start the web terminal / chat UI in background", ["status", "--no-auth", "--host"]),
     "setup":       ("Run interactive setup wizard",         []),
+    "theme":       ("List or set the console color theme",  []),
     "exit":        ("Exit cheetahclaws",              []),
     "quit":        ("Exit (alias for /exit)",             []),
     "resume":      ("Resume last session",                []),
@@ -1603,6 +1608,13 @@ def main():
     from providers import detect_provider, PROVIDERS
 
     config = load_config()
+
+    # Apply persisted console theme (if any) before any output is rendered.
+    try:
+        from ui.render import apply_theme as _apply_theme
+        _apply_theme(config.get("theme", "default"))
+    except Exception:
+        pass
 
     # Explicit bootstrap: configure logging, ensure tool registry is ready,
     # and start the optional health-check server.

--- a/commands/theme_cmd.py
+++ b/commands/theme_cmd.py
@@ -1,0 +1,44 @@
+"""
+commands/theme_cmd.py - /theme slash command for CheetahClaws.
+
+Usage:
+  /theme              List available themes (current marked with *)
+  /theme <name>       Apply a theme and persist it to config
+"""
+from __future__ import annotations
+
+from ui.render import THEMES, apply_theme, clr, info, ok, warn, err
+
+
+def cmd_theme(args: str, _state, config) -> bool:
+    name = (args or "").strip()
+    current = config.get("theme", "default")
+
+    if not name:
+        info("Available themes:")
+        for t, palette in THEMES.items():
+            marker = "*" if t == current else " "
+            swatch = clr("  accent  ", "cyan") + clr("  warn  ", "yellow")
+            line = f"  {marker} {t:<14} {swatch} ({palette['code']})"
+            print(line)
+        info("\nUsage: /theme <name>")
+        return True
+
+    if name not in THEMES:
+        err(f"Unknown theme: {name}")
+        info("Run /theme to list available themes.")
+        return True
+
+    if not apply_theme(name):
+        err(f"Failed to apply theme: {name}")
+        return True
+
+    config["theme"] = name
+    try:
+        from cc_config import save_config
+        save_config(config)
+    except Exception as e:
+        warn(f"Theme applied but could not be saved: {e}")
+
+    ok(f"Theme set to {clr(name, 'cyan')}.")
+    return True

--- a/ui/render.py
+++ b/ui/render.py
@@ -28,6 +28,38 @@ except ImportError:
     Markdown = None
 
 # ── ANSI helpers ───────────────────────────────────────────────────────────
+
+def _rgb(hex_str: str) -> str:
+    """Convert '#rrggbb' -> ANSI 24-bit foreground escape."""
+    h = hex_str.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+# Curated palettes (hex per semantic role). cyan/green/blue collapse to the
+# theme's accent color since CheetahClaws uses them all for primary chrome.
+# Add new entries here and they show up in `/theme` automatically.
+THEMES: dict = {
+    "default":     {"accent": "#00D7FF", "warn": "#FFAF00", "code": "monokai"},
+    "dracula":     {"accent": "#BD93F9", "warn": "#FFB86C", "code": "dracula"},
+    "nord":        {"accent": "#88C0D0", "warn": "#EBCB8B", "code": "nord"},
+    "gruvbox":     {"accent": "#FABD2F", "warn": "#FE8019", "code": "gruvbox-dark"},
+    "solarized":   {"accent": "#268BD2", "warn": "#B58900", "code": "solarized-dark"},
+    "tokyo-night": {"accent": "#7AA2F7", "warn": "#E0AF68", "code": "one-dark"},
+    "catppuccin":  {"accent": "#F5C2E7", "warn": "#FAB387", "code": "one-dark"},
+    "matrix":      {"accent": "#00FF41", "warn": "#CCFF00", "code": "monokai"},
+    "synthwave":   {"accent": "#FF00FF", "warn": "#FFCC00", "code": "fruity"},
+    "midnight":    {"accent": "#00BCD4", "warn": "#FFC107", "code": "dracula"},
+    "ocean":       {"accent": "#38BDF8", "warn": "#FBBF24", "code": "nord"},
+    "monokai":     {"accent": "#A6E22E", "warn": "#E6DB74", "code": "monokai"},
+    "cheetah":     {"accent": "#FFB000", "warn": "#FF6F00", "code": "monokai"},
+    "mono":        {"accent": "#E0E0E0", "warn": "#A0A0A0", "code": "bw"},
+    "none":        {"accent": "#FFFFFF", "warn": "#FFFFFF", "code": "default"},
+}
+
+# Active code-block style for Rich Markdown rendering.
+CODE_THEME: str = "monokai"
+
 C = {
     "cyan":    "\033[36m",
     "green":   "\033[32m",
@@ -40,6 +72,22 @@ C = {
     "dim":     "\033[2m",
     "reset":   "\033[0m",
 }
+
+
+def apply_theme(name: str) -> bool:
+    """Mutate the global ANSI color map in-place to a named theme."""
+    global CODE_THEME
+    p = THEMES.get(name)
+    if not p:
+        return False
+    accent = _rgb(p["accent"])
+    warn   = _rgb(p["warn"])
+    C["cyan"] = C["green"] = C["blue"] = accent
+    C["yellow"] = C["magenta"] = warn
+    C["red"]    = "\033[38;5;196m"
+    C["white"]  = "\033[97m"
+    CODE_THEME  = p["code"]
+    return True
 
 def clr(text: str, *keys: str) -> str:
     return "".join(C[k] for k in keys) + str(text) + C["reset"]


### PR DESCRIPTION
Adds a curated palette system to ui/render.py and a new /theme command:

- THEMES dict with 15 presets (default, dracula, nord, gruvbox, solarized, tokyo-night, catppuccin, matrix, synthwave, midnight, ocean, monokai, cheetah, mono, none) keyed by accent/warn hex + Rich code-block style.

- apply_theme(name) mutates the shared C ANSI map in-place so every existing clr()/info()/ok()/warn()/err() call switches palette without touching call sites.

- /theme lists palettes (current marked with *) and /theme <name> applies and persists to config via save_config(). Persisted theme is re-applied on startup right after load_config().

- Registered in COMMANDS and _CMD_META for tab-completion + /help auto-listing.