### PR TITLE
feat(prompt): inject live slash-command index into system prompt

### DIFF
--- a/cheetahclaws.py
+++ b/cheetahclaws.py
@@ -443,6 +443,23 @@ COMMANDS = {
 }
 
 # ── Load commands from modular/ ecosystem + installed plugins ──────────────
+def _register_external_meta(meta_dict: dict, cmd_name: str, cmd_def: dict) -> None:
+    """Populate _CMD_META for a modular/plugin command so it shows up in /help,
+    tab-completion, and the system-prompt slash-command index. Without this the
+    command is callable but invisible to those surfaces."""
+    if cmd_name in meta_dict:
+        return
+    help_field = cmd_def.get("help")
+    if isinstance(help_field, tuple) and len(help_field) >= 1:
+        desc = help_field[0]
+        subs = list(help_field[1]) if len(help_field) >= 2 and help_field[1] else []
+    elif isinstance(help_field, str):
+        desc, subs = help_field, []
+    else:
+        desc, subs = "External command", []
+    meta_dict[cmd_name] = (desc, subs)
+
+
 def _load_external_commands_into(commands_dict: dict) -> None:
     """Merge commands from modular/ modules and user-installed plugins into COMMANDS."""
     # 1. modular/ ecosystem (auto-discovered, ships with the project)
@@ -450,8 +467,10 @@ def _load_external_commands_into(commands_dict: dict) -> None:
         for cmd_name, cmd_def in _modular_load_commands().items():
             if cmd_name not in commands_dict and callable(cmd_def.get("func")):
                 commands_dict[cmd_name] = cmd_def["func"]
+                _register_external_meta(_CMD_META, cmd_name, cmd_def)
                 for alias in cmd_def.get("aliases", []):
                     commands_dict.setdefault(alias, cmd_def["func"])
+                    _CMD_META.setdefault(alias, (f"Alias for /{cmd_name}", []))
     except Exception:
         pass
 
@@ -461,12 +480,12 @@ def _load_external_commands_into(commands_dict: dict) -> None:
         for cmd_name, cmd_def in load_plugin_commands().items():
             if cmd_name not in commands_dict and callable(cmd_def.get("func")):
                 commands_dict[cmd_name] = cmd_def["func"]
+                _register_external_meta(_CMD_META, cmd_name, cmd_def)
                 for alias in cmd_def.get("aliases", []):
                     commands_dict.setdefault(alias, cmd_def["func"])
+                    _CMD_META.setdefault(alias, (f"Alias for /{cmd_name}", []))
     except Exception:
         pass
-
-_load_external_commands_into(COMMANDS)
 
 
 def __getattr__(name: str):
@@ -582,6 +601,12 @@ _CMD_META: dict[str, tuple[str, list[str]]] = {
     "quit":        ("Exit (alias for /exit)",             []),
     "resume":      ("Resume last session",                []),
 }
+
+
+# Merge modular/ + plugin commands into both COMMANDS and _CMD_META.
+# Must run after _CMD_META is defined so external commands show up in
+# tab-completion, /help, and the system-prompt slash-command index.
+_load_external_commands_into(COMMANDS)
 
 
 _rl_current_prompt = ""   # set by _read_input before each input() call

--- a/context.py
+++ b/context.py
@@ -189,15 +189,54 @@ def _tmux_available() -> bool:
         return False
 
 
+def _render_commands_block() -> str:
+    """Render a markdown list of every registered slash command.
+
+    Pulls live from ``cheetahclaws._CMD_META`` (lazy import to avoid the
+    cheetahclaws -> context -> cheetahclaws circular at module load), so
+    the prompt always reflects the current command surface — including
+    plugins merged in via ``_load_external_commands_into``.
+
+    Without this block the model has no idea what `/trading`,
+    `/research`, `/lab`, `/web`, `/wechat` etc. are and will confabulate
+    when the user asks "what can you do?" — see context.py docstring.
+    """
+    try:
+        import cheetahclaws as _cc
+    except ImportError:
+        return ""
+    meta = getattr(_cc, "_CMD_META", None)
+    if not meta:
+        return ""
+
+    lines = [
+        "# Available Slash Commands (User-invokable in this CheetahClaws session)",
+        "",
+        "These commands the **user** can invoke at the REPL prompt — they are"
+        " NOT tools you call. When the user asks 'what can you do?' / '你能做什么?'"
+        " / asks about a feature like trading or research or web UI, reference"
+        " these by their exact `/name` so the user can try them. Do not invent"
+        " commands that are not on this list.",
+        "",
+    ]
+    for name in sorted(meta.keys()):
+        desc, subs = meta[name]
+        sub_str = f" `[{' | '.join(subs)}]`" if subs else ""
+        lines.append(f"- `/{name}`{sub_str} — {desc}")
+    return "\n".join(lines)
+
+
 def build_system_prompt(config: dict | None = None) -> str:
     """Build the full system prompt for the current session.
 
     Structure (top → bottom):
         1. Provider-selected base prompt (``prompts/base/<provider>.md``)
         2. Per-run environment block (date, cwd, platform, git, CLAUDE.md)
-        3. Memory index (if any memories exist)
-        4. Tmux fragment (if tmux is installed)
-        5. Plan-mode fragment (if ``permission_mode == "plan"``)
+        3. Live slash-command index (so the model can answer
+           "what can you do?" without confabulating)
+        4. Memory index (if any memories exist)
+        5. Tmux fragment (if tmux is installed)
+        6. Plan-mode fragment (if ``permission_mode == "plan"``)
     """
     # Resolve provider lazily to avoid circular imports at module load.
     from providers import detect_provider
@@ -214,6 +253,10 @@ def build_system_prompt(config: dict | None = None) -> str:
         pick_base_prompt(provider, model_id),
         _render_env_block(cfg),
     ]
+
+    cmds_block = _render_commands_block()
+    if cmds_block:
+        parts.append(cmds_block)
 
     memory_ctx = get_memory_context()
     if memory_ctx:

--- a/tests/fixtures/golden_default_prompt.txt
+++ b/tests/fixtures/golden_default_prompt.txt
@@ -92,3 +92,63 @@ Return control to the user when:
 - Current date: <MASKED>
 - Working directory: <MASKED>
 - Platform: <MASKED>
+
+# Available Slash Commands (User-invokable in this CheetahClaws session)
+
+These commands the **user** can invoke at the REPL prompt — they are NOT tools you call. When the user asks 'what can you do?' / '你能做什么?' / asks about a feature like trading or research or web UI, reference these by their exact `/name` so the user can try them. Do not invent commands that are not on this list.
+
+- `/agent` `[start | stop | list | status | templates]` — Autonomous agent loop (task templates)
+- `/agents` — Show background agents
+- `/brainstorm` — Multi-persona AI debate + auto tasks
+- `/checkpoint` `[clear]` — List / restore checkpoints
+- `/circuit` `[status | reset]` — Show / reset per-provider circuit breakers
+- `/clear` — Clear conversation history
+- `/cloudsave` `[setup | auto | list | load | push]` — Cloud-sync sessions to GitHub Gist
+- `/compact` — Compact conversation history
+- `/config` — Show / set config key=value
+- `/context` — Show token-context usage
+- `/copy` — Copy last response to clipboard
+- `/cost` — Show cost estimate
+- `/cwd` — Show / change working directory
+- `/doctor` — Diagnose installation health
+- `/draft` — Draft 3 reply candidates for a message (manual copy)
+- `/exit` — Exit cheetahclaws
+- `/export` — Export conversation to file
+- `/help` — Show help
+- `/history` — Show conversation history
+- `/image` — Send clipboard image to model
+- `/img` — Send clipboard image (alias)
+- `/init` — Initialize CLAUDE.md template
+- `/lab` `[start | status | abort | logs | resume | iterate | backlog | daemon | models | migrate-paths]` — Autonomous research lab — multi-agent paper drafting + reviewer iteration
+- `/load` — Load a saved session
+- `/mcp` `[reload | add | remove | list]` — Manage MCP servers
+- `/memory` `[consolidate]` — Search / list / consolidate memories
+- `/model` — Show / set model
+- `/permissions` `[auto | accept-all | manual]` — Set permission mode
+- `/plan` `[done | status]` — Enter/exit plan mode
+- `/plugin` `[install | uninstall | enable | disable | disable-all | update | recommend | info]` — Manage plugins
+- `/proactive` `[off]` — Manage proactive background watcher
+- `/quit` — Exit (alias for /exit)
+- `/resume` — Resume last session
+- `/rewind` `[clear]` — Rewind to checkpoint (alias)
+- `/save` — Save session to file
+- `/search` — Search past sessions
+- `/setup` — Run interactive setup wizard
+- `/skills` — List available skills
+- `/slack` `[stop | status | logout]` — Slack bot bridge (Web API)
+- `/ssj` — SSJ Developer Mode — power menu
+- `/status` — Show session status and model info
+- `/task` `[create | delete | get | clear | todo | in-progress | done | blocked]` — Manage tasks (alias)
+- `/tasks` `[create | delete | get | clear | todo | in-progress | done | blocked]` — Manage tasks
+- `/telegram` `[stop | status]` — Telegram bot bridge
+- `/theme` — List or set the console color theme
+- `/thinking` — Toggle extended thinking
+- `/trade` — Alias for /trading
+- `/trading` `[analyze | backtest | price | indicators | status | history | memory]` — AI trading agent — multi-agent analysis and backtesting
+- `/tts` `[status]` — AI voice generator: text → any style → audio file
+- `/verbose` — Toggle verbose output
+- `/video` `[status | niches]` — AI video factory: story→voice→images→mp4
+- `/voice` `[lang | status | device]` — Voice input (record → STT)
+- `/web` `[status | --no-auth | --host]` — Start the web terminal / chat UI in background
+- `/wechat` `[stop | status]` — WeChat bridge (iLink Bot API)
+- `/worker` — Auto-implement pending tasks


### PR DESCRIPTION
Without this, the model has no idea what /trading, /research, /lab, /web, /wechat, /draft, … are. When the user asks "what can you do?" the model confabulates — making up commands or missing real ones.

context.build_system_prompt now appends a section pulled live from cheetahclaws._CMD_META:

    # Available Slash Commands (User-invokable in this CheetahClaws session)

    These commands the **user** can invoke at the REPL prompt — they
    are NOT tools you call. When the user asks "what can you do?" /
    "你能做什么?" / asks about a feature like trading or research or
    web UI, reference these by their exact `/name` so the user can
    try them. Do not invent commands that are not on this list.

    - `/agent` `[start | stop | list | status | templates]` — Autonomous agent loop …
    - `/lab`   `[start | status | abort | logs | resume | iterate | backlog | daemon | models | migrate-paths]` — …
    - `/draft` — Draft 3 reply candidates …
    …

Lazy-imports cheetahclaws to avoid a load-time cycle (cheetahclaws imports context). Fails gracefully (returns ""): on ImportError we just skip the section instead of breaking prompt assembly.

Sibling change in cheetahclaws._load_external_commands_into: modular/ commands and pip-installed plugin commands now register their metadata into _CMD_META via _register_external_meta(), so they show up in /help, tab-completion, AND the new slash-command index. Aliases register as "Alias for /<canonical>" so the index doesn't duplicate.

Golden prompt fixture updated to capture the new section.

Tests: 871 passing (added section visible in golden fixture, all prior prompt + theme tests still green; no regressions).