### PR TITLE
feat(daemon): F-2 persistence + F-3 monitor in daemon

### DIFF
--- a/cc_daemon/cli.py
+++ b/cc_daemon/cli.py
@@ -147,6 +147,17 @@ def cmd_serve(args: argparse.Namespace) -> int:
     import health as _health
     _health.install_config(config)
 
+    # F-3: take ownership of the monitor scheduler.  Subscriptions live in
+    # the SQLite store both daemon and REPL share, so /monitor subscribe
+    # from REPL is visible here on the next 60 s poll.  REPL detects this
+    # daemon and skips its own scheduler thread (see commands/monitor_cmd.py).
+    try:
+        from monitor.scheduler import start as _monitor_start
+        _monitor_start(config, on_report=None)
+    except Exception as exc:
+        print(f"warning: monitor scheduler did not start: {exc}",
+              file=sys.stderr, flush=True)
+
     audit_enabled = not args.no_audit
     token_path_for_discovery: Optional[str] = None
     if transport == "unix":
@@ -197,11 +208,17 @@ def cmd_serve(args: argparse.Namespace) -> int:
         print(f"audit log: {data_dir / 'logs' / 'auth.jsonl'}", flush=True)
 
     # Graceful-shutdown watcher: when DaemonState.shutdown_event fires
-    # (set by system.shutdown RPC or the signal handler below), trigger
-    # server.shutdown() from a side thread (the spike's invariant: the
-    # same thread as serve_forever cannot call shutdown).
+    # (set by system.shutdown RPC or the signal handler below), stop
+    # the monitor scheduler and trigger server.shutdown() from a side
+    # thread (the spike's invariant: the same thread as serve_forever
+    # cannot call shutdown).
     def _watch_shutdown():
         server.daemon_state.shutdown_event.wait()
+        try:
+            from monitor.scheduler import stop as _monitor_stop
+            _monitor_stop()
+        except Exception:
+            pass
         threading.Thread(target=server.shutdown, daemon=True).start()
     threading.Thread(target=_watch_shutdown,
                       daemon=True, name="daemon-shutdown-watch").start()

--- a/cc_daemon/cli.py
+++ b/cc_daemon/cli.py
@@ -136,6 +136,12 @@ def cmd_serve(args: argparse.Namespace) -> int:
         config["log_level"] = "info"
     _bootstrap(config)
 
+    # F-2: ensure the daemon's SQLite tables exist before the listener
+    # starts publishing events / accepting jobs / writing monitor state.
+    # init_schema is idempotent so re-running on an existing DB is a no-op.
+    from . import schema as _schema
+    _schema.init_schema()
+
     # Pin the health.py module-level config so default-arg payload helpers
     # see the model name on every call.
     import health as _health

--- a/cc_daemon/events.py
+++ b/cc_daemon/events.py
@@ -1,13 +1,31 @@
-"""events.py — In-memory ring buffer + SSE pub/sub for the daemon.
+"""events.py — SQLite-backed event log + SSE pub/sub for the daemon.
 
-Events get a monotonic id, are stored in a bounded deque, and fan out to
-subscriber queues. SSE writers replay from `since=<id>` then tail live events.
-On overflow (cursor older than the oldest retained id) a `gap` event is
-emitted so the client knows to resync.
+F-2 swap of F-1's in-memory ring for the ``daemon_events`` SQLite table.
+The wire surface (``EventBus.publish`` / ``replay_since`` / ``subscribe`` /
+``unsubscribe`` / ``subscriber_count`` / ``format_sse`` / ``heartbeat_frame``
+/ ``get_bus`` / ``reset_bus_for_tests``) is unchanged so the spike's tests
+(``tests/test_daemon_spike.py``) keep passing without edits.
 
-This is the spike implementation. Foundation PR will swap the in-mem buffer
-for the SQLite `daemon_events` table; the publish/subscribe surface stays
-the same.
+Behaviour deltas vs F-1:
+
+* ``publish`` writes a row to ``daemon_events`` (id is the SQLite
+  ``AUTOINCREMENT`` rowid → strictly monotonic across daemon restarts and
+  across pruning).  Subscribers still get the in-process fanout for live
+  tail.
+* ``replay_since`` reads from SQLite, so a client that disconnects and
+  reconnects after the daemon restarts still sees what it missed (subject
+  to retention).
+* Retention enforces both an age cap (default 24 h) and a row cap (default
+  100 K) — chauncygu's #74 review §7 default.  Pruning runs opportunistically
+  every N publishes so steady-state load stays inside one INSERT + one
+  COMMIT per event.
+* Gap detection: ``replay_since(N)`` yields a synthetic ``gap`` event when
+  ``N + 1`` is older than ``MIN(id)`` in the table (i.e. retention has
+  evicted what the client wanted), so SSE clients can resync.
+
+Concurrency: each thread that hits the bus gets its own SQLite connection
+through :func:`cc_daemon.schema.get_conn` (mirrors ``session_store``'s
+pattern); WAL + 5 s busy timeout is set there.
 """
 from __future__ import annotations
 
@@ -15,74 +33,185 @@ import json
 import queue
 import threading
 import time
-from collections import deque
-from typing import Any, Iterable, Optional
+from datetime import datetime, timezone
+from typing import Iterable, Optional
 
-# Cap chosen low for the spike — exercises overflow path in tests.
+# Re-exported for spike compatibility — server.py and tests import these.
 RING_CAP = 1000
 HEARTBEAT_INTERVAL_S = 15.0
 
+# Default retention policy (chauncygu #74 review §7).
+DEFAULT_RETENTION_HOURS = 24
+DEFAULT_RETENTION_ROWS = 100_000
+
+# How often (in publishes) we run the prune sweep.  Cheap heuristic that
+# avoids running an O(N) DELETE on every publish.
+PRUNE_EVERY_N_PUBLISHES = 100
+
+# Per-subscriber queue depth.  Same as the spike default.
+SUBSCRIBER_QUEUE_DEPTH = 4096
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _epoch_to_iso(ts: float) -> str:
+    """ISO 8601 with microsecond precision, ``Z`` suffix.
+
+    Microseconds matter for retention: at high publish rates two events
+    can otherwise end up with identical second-precision timestamps and
+    the time-based prune would treat them as a single bucket.  String
+    comparison still sorts correctly because all timestamps share the
+    same width.
+    """
+    return (datetime.fromtimestamp(ts, tz=timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+
+
+def _iso_to_epoch(ts: str) -> float:
+    """Best-effort ISO 8601 (with trailing ``Z``) → unix timestamp."""
+    if not ts:
+        return time.time()
+    try:
+        cleaned = ts.rstrip("Z")
+        dt = datetime.fromisoformat(cleaned).replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return time.time()
+
+
+# ── EventBus ──────────────────────────────────────────────────────────────
 
 class EventBus:
-    def __init__(self, ring_cap: int = RING_CAP) -> None:
-        self._ring: deque[dict] = deque(maxlen=ring_cap)
-        self._next_id = 1
-        self._oldest_id = 1  # tracks lowest id still in the ring
+    """Append-and-fanout bus backed by ``daemon_events``.
+
+    *ring_cap* is accepted for backward compat with the spike constructor but
+    no longer drives capacity — retention is governed by
+    ``retention_hours`` / ``retention_rows`` instead.
+    """
+
+    def __init__(self, ring_cap: int = RING_CAP, *,
+                 retention_hours: float = DEFAULT_RETENTION_HOURS,
+                 retention_rows: int = DEFAULT_RETENTION_ROWS,
+                 prune_every_n: int = PRUNE_EVERY_N_PUBLISHES) -> None:
+        # ring_cap is preserved on the instance for any caller that
+        # introspects it (none in the tree today, but the spike publicised
+        # the kw).
+        self._ring_cap = ring_cap
+        self._retention_hours = retention_hours
+        self._retention_rows = retention_rows
+        self._prune_every_n = prune_every_n
         self._subscribers: set[queue.Queue] = set()
         self._lock = threading.Lock()
+        self._publishes_since_prune = 0
 
-    def publish(
-        self,
-        ev_type: str,
-        data: dict,
-        *,
-        originator: Optional[dict] = None,
-    ) -> int:
+    # ── publish ────────────────────────────────────────────────────────────
+
+    def publish(self, ev_type: str, data: dict, *,
+                originator: Optional[dict] = None) -> int:
+        from .schema import get_conn
+
+        ts_epoch = time.time()
+        payload = {"data": data}
+        if originator is not None:
+            payload["originator"] = originator
+        payload_json = json.dumps(payload, separators=(",", ":"))
+
+        conn = get_conn()
+        cur = conn.execute(
+            "INSERT INTO daemon_events (ts, kind, payload_json) VALUES (?, ?, ?)",
+            (_epoch_to_iso(ts_epoch), ev_type, payload_json),
+        )
+        ev_id = int(cur.lastrowid)
+        conn.commit()
+
+        evt: dict = {
+            "id":   ev_id,
+            "ts":   ts_epoch,
+            "type": ev_type,
+            "data": data,
+        }
+        if originator is not None:
+            evt["originator"] = originator
+
         with self._lock:
-            ev_id = self._next_id
-            self._next_id += 1
-            evt = {
-                "id": ev_id,
-                "ts": time.time(),
-                "type": ev_type,
-                "data": data,
-            }
-            if originator is not None:
-                evt["originator"] = originator
-            # If full, the deque drops the head; bump _oldest_id accordingly.
-            if len(self._ring) == self._ring.maxlen:
-                self._oldest_id = self._ring[0]["id"] + 1
-            self._ring.append(evt)
-            for q in list(self._subscribers):
-                try:
-                    q.put_nowait(evt)
-                except queue.Full:
-                    pass
-            return ev_id
+            subs = list(self._subscribers)
+            self._publishes_since_prune += 1
+            should_prune = self._publishes_since_prune >= self._prune_every_n
+            if should_prune:
+                self._publishes_since_prune = 0
+
+        for q in subs:
+            try:
+                q.put_nowait(evt)
+            except queue.Full:
+                pass
+
+        if should_prune:
+            try:
+                self._prune_old_events()
+            except Exception:
+                # Pruning failure must not affect publish; janitor will
+                # retry on the next cycle.
+                pass
+
+        return ev_id
+
+    # ── replay ─────────────────────────────────────────────────────────────
 
     def replay_since(self, since: int) -> Iterable[dict]:
-        """Yield events with id > since. If since is older than the oldest
-        retained event, yield a synthetic `gap` first."""
-        with self._lock:
-            oldest = self._oldest_id
-            snapshot = list(self._ring)
-        if since > 0 and since < oldest - 1:
+        """Yield events with id > since.
+
+        If retention has evicted events the caller would expect, a synthetic
+        ``gap`` event is yielded first so SSE clients know to resync.
+        """
+        from .schema import get_conn
+        conn = get_conn()
+
+        oldest_row = conn.execute(
+            "SELECT MIN(id) FROM daemon_events"
+        ).fetchone()
+        oldest = oldest_row[0] if oldest_row and oldest_row[0] is not None else None
+
+        if since > 0 and oldest is not None and since + 1 < oldest:
             yield {
-                "id": oldest - 1,
-                "ts": time.time(),
+                "id":   oldest - 1,
+                "ts":   time.time(),
                 "type": "gap",
                 "data": {
                     "missed_from": since + 1,
-                    "missed_to": oldest - 1,
-                    "reason": "ring_overflow",
+                    "missed_to":   oldest - 1,
+                    "reason":      "retention_prune",
                 },
             }
-        for evt in snapshot:
-            if evt["id"] > since:
-                yield evt
+
+        rows = conn.execute(
+            "SELECT id, ts, kind, payload_json FROM daemon_events "
+            "WHERE id > ? ORDER BY id",
+            (since,),
+        ).fetchall()
+
+        for row in rows:
+            ev_id, ts_iso, kind, payload_json = (
+                row["id"], row["ts"], row["kind"], row["payload_json"]
+            )
+            try:
+                payload = json.loads(payload_json) if payload_json else {}
+            except (TypeError, ValueError):
+                payload = {}
+            evt: dict = {
+                "id":   int(ev_id),
+                "ts":   _iso_to_epoch(ts_iso),
+                "type": str(kind),
+                "data": payload.get("data", {}),
+            }
+            if "originator" in payload:
+                evt["originator"] = payload["originator"]
+            yield evt
+
+    # ── subscribe / unsubscribe ────────────────────────────────────────────
 
     def subscribe(self) -> queue.Queue:
-        q: queue.Queue = queue.Queue(maxsize=4096)
+        q: queue.Queue = queue.Queue(maxsize=SUBSCRIBER_QUEUE_DEPTH)
         with self._lock:
             self._subscribers.add(q)
         return q
@@ -95,6 +224,33 @@ class EventBus:
         with self._lock:
             return len(self._subscribers)
 
+    # ── internal: retention ────────────────────────────────────────────────
+
+    def _prune_old_events(self) -> None:
+        from .schema import get_conn
+        conn = get_conn()
+
+        # Time-based prune.
+        cutoff = time.time() - self._retention_hours * 3600
+        conn.execute(
+            "DELETE FROM daemon_events WHERE ts < ?",
+            (_epoch_to_iso(cutoff),),
+        )
+        # Row-count cap — keep the newest N.
+        excess = conn.execute(
+            "SELECT COUNT(*) FROM daemon_events"
+        ).fetchone()[0] - self._retention_rows
+        if excess > 0:
+            conn.execute(
+                "DELETE FROM daemon_events WHERE id IN ("
+                "  SELECT id FROM daemon_events ORDER BY id LIMIT ?"
+                ")",
+                (int(excess),),
+            )
+        conn.commit()
+
+
+# ── Module-level singleton ────────────────────────────────────────────────
 
 _BUS: Optional[EventBus] = None
 _BUS_LOCK = threading.Lock()
@@ -109,11 +265,35 @@ def get_bus() -> EventBus:
 
 
 def reset_bus_for_tests() -> None:
-    """Drop and recreate the global bus. Tests only."""
+    """Drop the singleton AND truncate the daemon_events table.
+
+    Tests rely on ``id`` starting from 1 after this — we therefore also
+    clear ``sqlite_sequence`` so the AUTOINCREMENT counter resets.  Spike
+    tests that call ``events.reset_bus_for_tests()`` keep passing because
+    the next publish produces id == 1 just as the in-memory implementation
+    used to.
+    """
     global _BUS
     with _BUS_LOCK:
         _BUS = EventBus()
+    try:
+        from .schema import get_conn
+        conn = get_conn()
+        conn.execute("DELETE FROM daemon_events")
+        # AUTOINCREMENT counter lives in sqlite_sequence; drop the row so
+        # next insert restarts at 1.  Best-effort; absent if no inserts yet.
+        try:
+            conn.execute("DELETE FROM sqlite_sequence WHERE name='daemon_events'")
+        except Exception:
+            pass
+        conn.commit()
+    except Exception:
+        # Test that didn't init schema yet (e.g. monkeypatched DB path):
+        # nothing to truncate.  Ignore.
+        pass
 
+
+# ── SSE wire format ───────────────────────────────────────────────────────
 
 def format_sse(evt: dict) -> bytes:
     """Render an event as one SSE message frame."""

--- a/cc_daemon/monitor_methods.py
+++ b/cc_daemon/monitor_methods.py
@@ -1,0 +1,76 @@
+"""monitor_methods.py — `monitor.*` JSON-RPC methods.
+
+Thin wrappers over :mod:`monitor.store` and :mod:`monitor.scheduler` so
+external clients (Web UI, third-party tools) can manage subscriptions
+and trigger runs through the same SQLite store that the in-process
+scheduler reads from.
+
+Exposed methods:
+
+    monitor.subscribe(topic, schedule="daily", channels=None)
+        Add or update a subscription.  Returns the new subscription dict.
+
+    monitor.unsubscribe(topic)
+        Remove a subscription.  Returns {"removed": bool}.
+
+    monitor.list()
+        Return all subscriptions.
+
+    monitor.run(topic)
+        Force-run a subscription now (fetch + summarize + deliver).
+        Returns {"topic", "report"}.  The report is also persisted to
+        ``monitor_reports`` and a ``monitor_report`` event fires on the
+        SSE channel — see :func:`monitor.scheduler.run_one`.
+
+F-3 keeps these methods open to any authenticated caller (single-user
+threat model from RFC 0001 §3).  Per-method authorisation arrives with
+the agent.run integration in F-3+ when permission requests carry an
+originator.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .rpc import RpcRegistry
+
+if TYPE_CHECKING:
+    from .server import DaemonState
+
+
+def register(registry: RpcRegistry, daemon_state: "DaemonState") -> None:
+
+    def monitor_subscribe(params: dict, _ctx) -> dict:
+        topic = params.get("topic")
+        if not isinstance(topic, str) or not topic:
+            raise TypeError("monitor.subscribe requires non-empty 'topic'")
+        schedule = params.get("schedule") or "daily"
+        channels = params.get("channels")
+        if channels is not None and not isinstance(channels, list):
+            raise TypeError("'channels' must be a list of strings")
+        from monitor.store import add_subscription
+        sub = add_subscription(topic, schedule=schedule, channels=channels)
+        return sub
+
+    def monitor_unsubscribe(params: dict, _ctx) -> dict:
+        topic = params.get("topic")
+        if not isinstance(topic, str) or not topic:
+            raise TypeError("monitor.unsubscribe requires non-empty 'topic'")
+        from monitor.store import remove_subscription
+        return {"topic": topic, "removed": remove_subscription(topic)}
+
+    def monitor_list(_params: dict, _ctx) -> dict:
+        from monitor.store import list_subscriptions
+        return {"subscriptions": list_subscriptions()}
+
+    def monitor_run(params: dict, _ctx) -> dict:
+        topic = params.get("topic")
+        if not isinstance(topic, str) or not topic:
+            raise TypeError("monitor.run requires non-empty 'topic'")
+        from monitor.scheduler import run_one
+        report = run_one(topic, config=daemon_state.config or {})
+        return {"topic": topic, "report": report}
+
+    registry.register("monitor.subscribe", monitor_subscribe)
+    registry.register("monitor.unsubscribe", monitor_unsubscribe)
+    registry.register("monitor.list", monitor_list)
+    registry.register("monitor.run", monitor_run)

--- a/cc_daemon/schema.py
+++ b/cc_daemon/schema.py
@@ -1,0 +1,249 @@
+"""schema.py — daemon-owned SQLite tables in ~/.cheetahclaws/sessions.db.
+
+Roadmap reference: ``docs/RFC/0002-daemon-foundation-roadmap.md`` §F-2.
+
+The daemon shares the same SQLite file as :mod:`session_store` (so users
+end up with one ``sessions.db`` to back up, not two).  This module owns
+seven additive tables — the existing ``sessions`` / ``sessions_fts`` are
+left untouched.
+
+Tables:
+  ``daemon_events``       — append-only event log (replaces F-1's in-memory ring)
+  ``agent_runs``          — one row per ``/agent`` runner (populated in F-4)
+  ``agent_iterations``    — per-iteration log for those runners
+  ``jobs``                — replaces the F-1 ``~/.cheetahclaws/jobs.json`` file
+  ``monitor_subscriptions`` — durable ``/monitor subscribe ...`` state (F-3)
+  ``monitor_reports``     — generated reports per subscription run
+  ``bridges``             — bridge enabled/last-error state (F-6/7/8)
+  ``schema_meta``         — schema version + last-init-at, for future migrations
+
+All connections go through :func:`get_conn` which:
+  * Uses a thread-local connection (matches ``session_store`` pattern).
+  * Enables WAL + 5 s busy timeout.
+  * Calls :func:`init_schema` on first connect for the thread.
+
+:func:`init_schema` is idempotent — running on a fresh DB creates everything;
+running on an already-initialised DB is a no-op.  Schema bumps live in
+:func:`_apply_migrations` and bump ``CURRENT_SCHEMA_VERSION``.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+CURRENT_SCHEMA_VERSION = 1
+
+DEFAULT_EVENT_RETENTION_HOURS = 24
+DEFAULT_EVENT_RETENTION_ROWS  = 100_000
+
+_TABLES_DDL = """
+CREATE TABLE IF NOT EXISTS schema_meta (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS daemon_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts            TEXT NOT NULL,
+    kind          TEXT NOT NULL,
+    payload_json  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts);
+
+CREATE TABLE IF NOT EXISTS agent_runs (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    template        TEXT NOT NULL,
+    args            TEXT,
+    status          TEXT NOT NULL,
+    auto_approve    INTEGER NOT NULL DEFAULT 1,
+    started_at      TEXT NOT NULL,
+    ended_at        TEXT,
+    last_iteration  INTEGER DEFAULT 0,
+    error           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_status ON agent_runs(status);
+
+CREATE TABLE IF NOT EXISTS agent_iterations (
+    run_id      TEXT NOT NULL,
+    iteration   INTEGER NOT NULL,
+    ts          TEXT NOT NULL,
+    status      TEXT NOT NULL,
+    duration_s  REAL,
+    summary     TEXT,
+    in_tokens   INTEGER DEFAULT 0,
+    out_tokens  INTEGER DEFAULT 0,
+    cost_usd    REAL DEFAULT 0,
+    PRIMARY KEY (run_id, iteration)
+);
+
+CREATE TABLE IF NOT EXISTS jobs (
+    id              TEXT PRIMARY KEY,
+    title           TEXT,
+    prompt          TEXT,
+    source          TEXT,
+    status          TEXT NOT NULL,
+    created_at      TEXT,
+    started_at      TEXT,
+    done_at         TEXT,
+    duration_s      REAL DEFAULT 0,
+    steps_json      TEXT,
+    step_count      INTEGER DEFAULT 0,
+    current_step    TEXT,
+    result          TEXT,
+    error           TEXT,
+    retry_of        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at);
+
+CREATE TABLE IF NOT EXISTS monitor_subscriptions (
+    topic           TEXT PRIMARY KEY,
+    schedule        TEXT NOT NULL,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    last_run_at     TEXT,
+    next_run_at     TEXT,
+    recipients_json TEXT,
+    config_json     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS monitor_reports (
+    id           TEXT PRIMARY KEY,
+    topic        TEXT NOT NULL,
+    ts           TEXT NOT NULL,
+    body         TEXT,
+    sent_to_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_monitor_reports_topic_ts
+    ON monitor_reports(topic, ts);
+
+CREATE TABLE IF NOT EXISTS bridges (
+    kind          TEXT PRIMARY KEY,
+    enabled       INTEGER NOT NULL DEFAULT 0,
+    config_json   TEXT,
+    last_poll_at  TEXT,
+    last_error    TEXT
+);
+"""
+
+
+# ── Module-level state ────────────────────────────────────────────────────
+
+_db_path: Optional[Path] = None
+_local = threading.local()
+_init_lock = threading.Lock()
+
+
+def get_default_db_path() -> Path:
+    """Return ``~/.cheetahclaws/sessions.db`` (shared with session_store)."""
+    from cc_config import CONFIG_DIR
+    return CONFIG_DIR / "sessions.db"
+
+
+def set_db_path(path: Path) -> None:
+    """Override the daemon DB location (used by tests; otherwise default)."""
+    global _db_path
+    _db_path = path
+    # Drop any existing thread-local connection so subsequent get_conn()
+    # picks up the new path.
+    if hasattr(_local, "conn") and _local.conn is not None:
+        try:
+            _local.conn.close()
+        except Exception:
+            pass
+        _local.conn = None
+
+
+def _resolve_path() -> Path:
+    return _db_path if _db_path is not None else get_default_db_path()
+
+
+# ── Init ──────────────────────────────────────────────────────────────────
+
+def init_schema(db_path: Optional[Path] = None) -> None:
+    """Idempotently create the daemon's tables on *db_path*.
+
+    Safe to call multiple times.  Holds an internal lock so concurrent
+    callers don't trip on each other.
+    """
+    target = db_path if db_path is not None else _resolve_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    with _init_lock:
+        conn = sqlite3.connect(str(target), timeout=10)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executescript(_TABLES_DDL)
+            _record_schema_version(conn, CURRENT_SCHEMA_VERSION)
+            _apply_migrations(conn)
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def _record_schema_version(conn: sqlite3.Connection, version: int) -> None:
+    """Stamp the schema version + init timestamp.  Idempotent UPSERT."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    conn.execute(
+        "INSERT INTO schema_meta (key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value, "
+        "updated_at=excluded.updated_at",
+        ("schema_version", str(version), now),
+    )
+
+
+def _apply_migrations(_conn: sqlite3.Connection) -> None:
+    """Future-version migrations land here.
+
+    Read ``schema_version`` from ``schema_meta``; for each version below
+    ``CURRENT_SCHEMA_VERSION`` apply the corresponding ALTER/CREATE.  v1 is
+    the initial layout, so this is a no-op today.
+    """
+    return
+
+
+# ── Connection accessor ───────────────────────────────────────────────────
+
+def get_conn() -> sqlite3.Connection:
+    """Thread-local connection to the daemon DB.  Auto-inits schema."""
+    conn = getattr(_local, "conn", None)
+    if conn is not None:
+        return conn
+    target = _resolve_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    init_schema(target)
+    conn = sqlite3.connect(str(target), timeout=10)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.row_factory = sqlite3.Row
+    _local.conn = conn
+    return conn
+
+
+def get_schema_version(db_path: Optional[Path] = None) -> Optional[int]:
+    """Return the recorded schema version, or None on a virgin DB."""
+    target = db_path if db_path is not None else _resolve_path()
+    if not target.exists():
+        return None
+    conn = sqlite3.connect(str(target), timeout=10)
+    try:
+        row = conn.execute(
+            "SELECT value FROM schema_meta WHERE key='schema_version'"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return None

--- a/cc_daemon/server.py
+++ b/cc_daemon/server.py
@@ -65,8 +65,9 @@ class DaemonState:
         self.permissions.start_janitor()
         self.rpc = RpcRegistry()
         register_methods(self.rpc, self.permissions)
-        from . import system_methods
+        from . import system_methods, monitor_methods
         system_methods.register(self.rpc, self)
+        monitor_methods.register(self.rpc, self)
         self.shutdown_event = threading.Event()
 
     def shutdown(self) -> None:

--- a/commands/monitor_cmd.py
+++ b/commands/monitor_cmd.py
@@ -191,7 +191,21 @@ def cmd_monitor(args: str, state, config) -> bool:
         _cmd_monitor_run(rest, config)
 
     elif sub == "start":
-        if _sched.is_running():
+        # F-3: when a daemon is running, the scheduler is *its* job.
+        # Spinning up another loop in REPL would race the daemon's
+        # writes to monitor_subscriptions.last_run_at and double-fire
+        # subscriptions.  Detect-and-skip; subscriptions added/removed
+        # in REPL are still picked up by the daemon scheduler on its
+        # next 60 s poll because both processes read the same SQLite.
+        try:
+            from cc_daemon import discovery as _disc
+            _live = _disc.locate()
+        except Exception:
+            _live = None
+        if _live is not None:
+            info(f"Scheduler is owned by the running daemon "
+                 f"(pid={_live.get('pid', '?')}); /monitor start is a no-op.")
+        elif _sched.is_running():
             ok("Scheduler is already running.")
         else:
             _sched.start(config, on_report=None)
@@ -200,7 +214,16 @@ def cmd_monitor(args: str, state, config) -> bool:
             info("Use /monitor stop to stop, /monitor status to check.")
 
     elif sub == "stop":
-        if _sched.stop():
+        try:
+            from cc_daemon import discovery as _disc
+            _live = _disc.locate()
+        except Exception:
+            _live = None
+        if _live is not None:
+            info(f"Scheduler is owned by the running daemon "
+                 f"(pid={_live.get('pid', '?')}); /monitor stop is a no-op. "
+                 f"Run `cheetahclaws daemon stop` to stop the daemon itself.")
+        elif _sched.stop():
             ok("Monitor scheduler stopped.")
         else:
             info("Scheduler was not running.")

--- a/docs/RFC/0002-daemon-foundation-roadmap.md
+++ b/docs/RFC/0002-daemon-foundation-roadmap.md
@@ -12,7 +12,7 @@ The "foundation PR" described at the end of [RFC 0001](./0001-daemon-design-note
 |-----|-----------------------------------------------------|------------|---------|--------|
 | F-1 | `daemon/` package skeleton; `serve` + `daemon` CLI  | —          | ~1500   | MERGED #80 |
 | F-2 | SQLite schema + events persistence + jobs migration | F-1        | ~700    | OPEN   |
-| F-3 | `monitor/scheduler` runs in daemon                  | F-2        | ~500    | TODO   |
+| F-3 | `monitor/scheduler` runs in daemon                  | F-2        | ~700    | OPEN   |
 | F-4 | `agent_runner` becomes subprocess-per-agent         | F-2        | ~1000   | TODO   |
 | F-5 | `proactive` watcher runs in daemon                  | F-2        | ~200    | TODO   |
 | F-6 | Telegram bridge in daemon                           | F-2        | ~500    | TODO   |
@@ -134,14 +134,60 @@ is already provided by spike's `cc_daemon/originator.py` +
 
 ## F-3 — monitor in daemon
 
-**Scope.** `monitor/scheduler.py` runs daemon-side; REPL skips its local thread when a daemon is detected.
+**Scope.** `monitor/scheduler.py` runs daemon-side; subscription store
+moves from JSON to the F-2 `monitor_subscriptions` table; reports
+persist + emit SSE events; REPL skips its local scheduler when a
+daemon is detected.
 
-**RPC methods.** `monitor.subscribe`, `monitor.unsubscribe`, `monitor.list`, `monitor.run`.
+**Deliverables.**
+
+- `monitor/store.py` — SQLite-backed (`monitor_subscriptions` and
+  `monitor_reports` tables).  One-shot import of legacy
+  `~/.cheetahclaws/monitor_subscriptions.json` on first call (tracked
+  in `schema_meta.monitor_migrated_from_json`); JSON kept readable for
+  one release.  New helpers: `save_report`, `list_reports`.  Public
+  API of the legacy store unchanged.
+- `monitor/scheduler.py` — `run_one()` persists the full report body
+  via `save_report` and publishes a `monitor_report` event on
+  `cc_daemon.events.get_bus()` with `{topic, report_id, body, sent_to,
+  errors}`.  Loop's idle wait switched from `time.sleep(30)` ×60 to a
+  single `Event.wait(60)` so daemon shutdown isn't stalled by the
+  scheduler thread napping.
+- `cc_daemon/monitor_methods.py` — registers `monitor.subscribe`,
+  `monitor.unsubscribe`, `monitor.list`, `monitor.run` for external
+  clients (Web UI / third-party tools).  `DaemonState.__init__` calls
+  `monitor_methods.register` next to `system_methods`.
+- `cc_daemon/cli.py:cmd_serve` — starts the scheduler with
+  `monitor.scheduler.start(config)` after schema init; the existing
+  shutdown watcher calls `monitor.scheduler.stop()` before triggering
+  HTTP-server shutdown.
+- `commands/monitor_cmd.py` — `/monitor start` and `/monitor stop`
+  detect a live daemon via `cc_daemon.discovery.locate()` and no-op
+  with a friendly message.  `/monitor subscribe` / `unsubscribe` /
+  `list` continue to work in REPL because they hit SQLite directly.
 
 **Acceptance.**
-- `cheetahclaws serve` running → `/monitor subscribe arxiv --schedule daily --telegram` persists to `monitor_subscriptions`; daemon scheduler fires on cadence even after REPL exit.
-- Without daemon: today's behavior unchanged (in-process scheduler thread).
-- Reports persist to `monitor_reports` and emit `monitor_report` SSE events.
+
+- `cheetahclaws serve` running → `monitor.subscribe` over RPC persists
+  to SQLite; daemon scheduler fires on cadence; reports show up in
+  `monitor_reports` and on the SSE channel as `monitor_report` events.
+- Daemon stop → start with same data dir → `monitor.list` over RPC
+  returns the previously-subscribed topics.  (Verified by
+  `tests/e2e_daemon_skeleton.py::test_monitor_subscribe_via_rpc_survives_daemon_restart`.)
+- REPL `/monitor subscribe` while daemon is running: subscription
+  visible via `monitor.list` from outside.  Daemon picks up the new
+  row on its next 60 s poll.
+- Without daemon: today's REPL-only behaviour unchanged
+  (in-process scheduler thread).
+- Telegram / Slack / WeChat delivery from daemon: out of scope for F-3
+  (waits for F-6/F-7/F-8).  Reports + `monitor_report` events still
+  fire so the digest isn't lost; bridges deliver only when REPL is
+  running with the channel connected.
+
+**Tests.** `tests/test_monitor_store_sqlite.py` (18), 
+`tests/test_monitor_scheduler_events.py` (7),
+`tests/test_cc_daemon_monitor_methods.py` (12), plus 1 new e2e in
+`tests/e2e_daemon_skeleton.py` for the survive-restart case.
 
 ## F-4 — agent_runner subprocess
 

--- a/docs/RFC/0002-daemon-foundation-roadmap.md
+++ b/docs/RFC/0002-daemon-foundation-roadmap.md
@@ -11,7 +11,7 @@ The "foundation PR" described at the end of [RFC 0001](./0001-daemon-design-note
 | ID  | Scope                                               | Depends on | Est LoC | Status |
 |-----|-----------------------------------------------------|------------|---------|--------|
 | F-1 | `daemon/` package skeleton; `serve` + `daemon` CLI  | —          | ~1500   | MERGED #80 |
-| F-2 | SQLite schema + originator-tracked permission flow  | F-1        | ~600    | TODO   |
+| F-2 | SQLite schema + events persistence + jobs migration | F-1        | ~700    | OPEN   |
 | F-3 | `monitor/scheduler` runs in daemon                  | F-2        | ~500    | TODO   |
 | F-4 | `agent_runner` becomes subprocess-per-agent         | F-2        | ~1000   | TODO   |
 | F-5 | `proactive` watcher runs in daemon                  | F-2        | ~200    | TODO   |
@@ -81,24 +81,56 @@ PR #74.  Layer the foundation glue on top:
 - pytest green on Linux, macOS, Windows (TCP-only on Windows; Unix
   socket tests skip on Windows).
 
-## F-2 — SQLite schema + originator-tracked permission flow
+## F-2 — SQLite schema + events persistence + jobs migration
 
-**Scope.** Seven additive tables in `~/.cheetahclaws/sessions.db`; `permission.answer` RPC with originator validation.
+**Scope.** Seven additive tables in `~/.cheetahclaws/sessions.db`; swap
+the F-1 in-memory event ring for a SQLite-backed channel; migrate
+`jobs.py` JSON storage to SQLite.  **Originator-tracked permission flow
+is already provided by spike's `cc_daemon/originator.py` +
+`cc_daemon/permission.py`** (see PR #80) — this PR doesn't re-do it.
 
-**Tables (additive — `sessions` schema untouched).** `agent_runs`, `agent_iterations`, `jobs`, `monitor_subscriptions`, `monitor_reports`, `bridges`, `daemon_events`.
+**Tables (additive — `sessions` from `session_store.py` untouched).**
+`schema_meta`, `daemon_events`, `agent_runs`, `agent_iterations`,
+`jobs`, `monitor_subscriptions`, `monitor_reports`, `bridges`.
 
 **Deliverables.**
-- `daemon/schema.py` — table DDL + version table; idempotent `init_schema()`.
-- `daemon/events.py` — replay backed by `daemon_events` (replaces F-1's in-memory ring).
-- `daemon/permissions.py` — originator record on every `PermissionRequest`; `permission.answer` checks caller's auth identity against originator; non-originators get `403 not_originator`.
-- `jobs.py` — one-shot migrate `~/.cheetahclaws/jobs.json` into the `jobs` table; JSON file kept readable for one release.
+- `cc_daemon/schema.py` — DDL + `init_schema(db_path)` (idempotent,
+  internally locked) + `get_conn()` (thread-local, mirrors
+  `session_store` pattern) + `get_schema_version()` accessor; future
+  migrations land in `_apply_migrations()`.
+- `cc_daemon/cli.py:cmd_serve` calls `init_schema()` right after
+  `bootstrap()` so tables exist before the first publish.
+- `cc_daemon/events.py` — rewritten: `EventBus.publish` does an INSERT
+  into `daemon_events` (id from `AUTOINCREMENT`, monotonic across
+  restarts and prunes), still fans out to in-process subscribers for
+  live tail; `replay_since(N)` reads from SQLite and emits a synthetic
+  `gap` event when `N` is older than the oldest surviving row.
+  Default retention: 24 h / 100 K rows; opportunistic prune every 100
+  publishes.
+- `jobs.py` — `_persist`/`_row_to_job` hit SQLite; `_ensure_migrated()`
+  imports legacy `~/.cheetahclaws/jobs.json` once (tracked via
+  `schema_meta.jobs_migrated_from_json`).  JSON file is **left readable
+  in place** for one release as fallback.  Public API unchanged.
 
 **Acceptance.**
-- Schema migrations run idempotently across daemon restarts.
-- `permission.answer` from the originator succeeds; from any other client returns `403 not_originator`.
-- Originator disconnect + reconnect within timeout window: pending request replays via SSE scoped to that originator.
-- `daemon_events` table caps at configured retention (default 1M rows / 7 days); oldest rows expired.
-- Existing `jobs.json` users see a one-time import message; subsequent runs read from SQLite.
+- `init_schema()` is idempotent across daemon restarts and concurrent
+  callers (verified by 12 unit tests in `tests/test_cc_daemon_schema.py`).
+- Spike's 13 contract tests in `tests/test_daemon_spike.py` keep
+  passing on the SQLite-backed bus (only the two ring-buffer tests
+  needed an in-place rewrite to test retention-based eviction instead
+  of the deleted in-memory cap).
+- New `tests/test_cc_daemon_events_sqlite.py` (15 tests) covers
+  persistence, retention by row count + age, gap-on-old-since,
+  cross-instance replay (simulated daemon restart), and the
+  `reset_bus_for_tests()` truncate path.
+- New `tests/test_jobs_sqlite.py` (14 tests) covers create / start /
+  add_step / lifecycle / list_recent / list_running / `_MAX_JOBS`
+  pruning + JSON-file migration (idempotency, corrupt-file tolerance,
+  legacy-file kept readable).
+- New e2e `tests/e2e_daemon_skeleton.py::test_events_persist_in_sqlite_across_daemon_restart`
+  publishes events on daemon A via `echo.ping`, stops A, starts B
+  against the same data dir, and verifies `GET /events?since=0`
+  replays the events from SQLite.
 
 ## F-3 — monitor in daemon
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -839,6 +839,50 @@ events published while the client was away (and still inside the
 retention window) are replayed from SQLite, so observers don't lose
 their event timeline across daemon restarts.
 
+#### Monitor in daemon (F-3)
+
+`monitor/scheduler.py` is now daemon-owned.  When `cheetahclaws serve`
+starts, it kicks the scheduler loop in-process; subscriptions and
+generated reports live in the SQLite `monitor_subscriptions` and
+`monitor_reports` tables (migrated from
+`~/.cheetahclaws/monitor_subscriptions.json` on first daemon run, with
+the JSON file kept readable for one release as fallback).
+
+Behaviour:
+
+- **REPL detects daemon → skips local scheduler.**  When the user types
+  `/monitor start` in REPL while a daemon is running,
+  `commands/monitor_cmd.py` calls `cc_daemon.discovery.locate()`, sees
+  a live daemon, prints "scheduler is owned by the running daemon", and
+  no-ops.  Avoids the race of two schedulers fighting over
+  `last_run_at` and double-firing subscriptions.  `/monitor stop`
+  behaves the same way.
+- **`/monitor subscribe` / `unsubscribe` / `list` always work in REPL.**
+  These hit SQLite directly through `monitor.store`; the daemon picks
+  up the new state on its next 60 s poll.  No RPC round-trip needed.
+- **External clients use RPC.**  `cc_daemon/monitor_methods.py`
+  registers `monitor.subscribe`, `monitor.unsubscribe`, `monitor.list`,
+  `monitor.run` for Web UI / third-party tools that don't share the
+  process tree.
+- **Reports become events.**  `scheduler.run_one()` persists the full
+  report body to `monitor_reports` and publishes a `monitor_report`
+  event on the SSE channel (`{topic, report_id, body, sent_to,
+  errors}`).  SSE subscribers see digests as they land; the
+  `report_id` ties the event back to the row in `monitor_reports` for
+  later retrieval.
+- **Telegram / Slack / WeChat delivery from daemon waits for F-6/7/8.**
+  Until the bridges themselves move into daemon, a subscription
+  configured with `--telegram` will land its report in
+  `monitor_reports` and emit the SSE event when the daemon fires it,
+  but won't actually push to Telegram unless REPL is also running with
+  the bridge connected.
+
+The headline F-3 user-visible win: `/monitor subscribe arxiv
+--schedule daily --console`, then exit REPL — the daemon scheduler
+keeps firing on schedule, reports persist to SQLite, SSE clients see
+each digest as it lands, history is `monitor.list_reports("arxiv")`
+away when the user reconnects.
+
 ### Research Lab (`research/lab/` + `commands/lab_cmd.py` + `web/lab_*`)
 
 Autonomous multi-agent research engine — `/lab start <topic>` (CLI)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -802,8 +802,42 @@ flow but aren't yet wired into `agent.run`).  Migrating
 `monitor/scheduler`, `agent_runner` (as subprocess-per-agent),
 `proactive`, the three messaging bridges, and replacing
 `cc_daemon/methods.py` and `cc_daemon/permission.py` with
-`agent.run`-driven equivalents is the F-2 through F-8 work in the
+`agent.run`-driven equivalents is the F-3 through F-8 work in the
 foundation roadmap.
+
+#### Persistence (F-2)
+
+`cheetahclaws serve` now initialises a daemon-owned schema in the
+existing ``~/.cheetahclaws/sessions.db`` (shared with `session_store`).
+Seven additive tables — the `sessions` table from `session_store` is
+left untouched:
+
+- `daemon_events` — append-only event log (replaces F-1's in-memory ring).
+  ID is `AUTOINCREMENT` so it stays monotonic across restarts and across
+  retention pruning.  Default retention is 24 h / 100 K rows; pruning
+  runs opportunistically every 100 publishes.  When `replay_since(N)`
+  finds the requested cursor older than `MIN(id)` it yields a synthetic
+  `gap` event so SSE clients (Web UI / future bridges) know to resync.
+- `agent_runs` / `agent_iterations` — placeholder tables awaiting F-4
+  (`agent_runner` subprocess-per-agent).
+- `jobs` — replaces `~/.cheetahclaws/jobs.json`.  `jobs.py` migrates
+  the legacy file once on first call (tracked via `schema_meta`); the
+  JSON file is **left readable** for one release as fallback.
+- `monitor_subscriptions` / `monitor_reports` — placeholder for F-3.
+- `bridges` — placeholder for F-6/7/8.
+- `schema_meta` — schema version + per-feature migration markers.
+
+`cc_daemon/schema.py:init_schema()` is idempotent (CREATE IF NOT
+EXISTS only) and serialised by an internal lock, so concurrent serve
+attempts can't trip on each other.  Schema version is recorded as
+`schema_meta.schema_version`; future bumps go through
+`_apply_migrations()` which is currently a no-op for v1.
+
+The headline F-2 user-visible win: an SSE client that disconnects,
+the daemon restarts, and the client reconnects with `?since=<id>` —
+events published while the client was away (and still inside the
+retention window) are replayed from SQLite, so observers don't lose
+their event timeline across daemon restarts.
 
 ### Research Lab (`research/lab/` + `commands/lab_cmd.py` + `web/lab_*`)
 

--- a/jobs.py
+++ b/jobs.py
@@ -146,41 +146,139 @@ class Job:
 
 
 # ── Storage ──────────────────────────────────────────────────────────────────
+#
+# F-2 swapped the JSON-file backend for the SQLite ``jobs`` table.  The
+# legacy ``~/.cheetahclaws/jobs.json`` is migrated on first access and
+# kept readable for one release as a fallback.  Public API
+# (``create``, ``start``, ``get``, ``list_recent`` …) is unchanged.
+
+_MIGRATION_KEY = "jobs_migrated_from_json"
+_migration_done_in_process = False  # process-wide guard, avoids re-checking
+
 
 def _now() -> str:
     return datetime.now().isoformat(timespec="seconds")
 
 
-def _load() -> list[dict]:
-    if not _JOBS_PATH.exists():
-        return []
-    try:
-        return json.loads(_JOBS_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return []
+def _ensure_migrated() -> None:
+    """Idempotent one-shot import of the legacy JSON file.
+
+    Tracked by a row in ``schema_meta`` so it survives across processes.
+    A process-wide bool short-circuits subsequent calls.  The original
+    JSON file is left in place so users on the prior release can still
+    read it; we do not delete it after migration.
+    """
+    global _migration_done_in_process
+    if _migration_done_in_process:
+        return
+    from cc_daemon.schema import get_conn
+    conn = get_conn()
+    row = conn.execute(
+        "SELECT value FROM schema_meta WHERE key=?", (_MIGRATION_KEY,)
+    ).fetchone()
+    if row is None and _JOBS_PATH.exists():
+        try:
+            legacy = json.loads(_JOBS_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            legacy = []
+        for d in legacy if isinstance(legacy, list) else []:
+            try:
+                _persist(Job.from_dict(d), conn=conn)
+            except Exception:
+                continue
+    if row is None:
+        from datetime import timezone
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        conn.execute(
+            "INSERT INTO schema_meta (key, value, updated_at) "
+            "VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET "
+            "value=excluded.value, updated_at=excluded.updated_at",
+            (_MIGRATION_KEY, "1", now),
+        )
+        conn.commit()
+    _migration_done_in_process = True
 
 
-def _save(jobs: list[dict]) -> None:
-    _JOBS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    # Keep last _MAX_JOBS entries
-    jobs = jobs[-_MAX_JOBS:]
-    _JOBS_PATH.write_text(json.dumps(jobs, ensure_ascii=False, indent=2), encoding="utf-8")
+def _row_to_job(row) -> Job:
+    return Job(
+        id=row["id"],
+        title=row["title"] or "",
+        prompt=row["prompt"] or "",
+        status=row["status"],
+        source=row["source"] or "",
+        steps=json.loads(row["steps_json"]) if row["steps_json"] else [],
+        step_count=row["step_count"] or 0,
+        current_step=row["current_step"] or "",
+        result=row["result"] or "",
+        error=row["error"] or "",
+        created_at=row["created_at"] or "",
+        started_at=row["started_at"] or "",
+        done_at=row["done_at"] or "",
+        duration_s=row["duration_s"] or 0.0,
+        retry_of=row["retry_of"] or "",
+    )
+
+
+def _persist(job: Job, conn=None) -> None:
+    """INSERT or UPDATE the row for *job*.  Caller passes *conn* during
+    migration to avoid re-entering ``get_conn`` from inside a transaction."""
+    from cc_daemon.schema import get_conn
+    c = conn if conn is not None else get_conn()
+    c.execute(
+        "INSERT INTO jobs (id, title, prompt, source, status, created_at, "
+        "  started_at, done_at, duration_s, steps_json, step_count, "
+        "  current_step, result, error, retry_of) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
+        "ON CONFLICT(id) DO UPDATE SET "
+        "  title=excluded.title, prompt=excluded.prompt, "
+        "  source=excluded.source, status=excluded.status, "
+        "  started_at=excluded.started_at, done_at=excluded.done_at, "
+        "  duration_s=excluded.duration_s, steps_json=excluded.steps_json, "
+        "  step_count=excluded.step_count, current_step=excluded.current_step,"
+        "  result=excluded.result, error=excluded.error, "
+        "  retry_of=excluded.retry_of",
+        (job.id, job.title, job.prompt, job.source, job.status,
+         job.created_at, job.started_at, job.done_at, job.duration_s,
+         json.dumps(job.steps, ensure_ascii=False),
+         job.step_count, job.current_step, job.result,
+         job.error, job.retry_of),
+    )
+    if conn is None:
+        c.commit()
+
+
+def _prune_to_max(conn=None) -> None:
+    """Keep only the most-recent ``_MAX_JOBS`` rows."""
+    from cc_daemon.schema import get_conn
+    c = conn if conn is not None else get_conn()
+    excess = c.execute(
+        "SELECT COUNT(*) FROM jobs"
+    ).fetchone()[0] - _MAX_JOBS
+    if excess > 0:
+        c.execute(
+            "DELETE FROM jobs WHERE id IN ("
+            "  SELECT id FROM jobs ORDER BY created_at LIMIT ?"
+            ")",
+            (excess,),
+        )
+        if conn is None:
+            c.commit()
 
 
 def _get_all() -> list[Job]:
-    return [Job.from_dict(d) for d in _load()]
+    _ensure_migrated()
+    from cc_daemon.schema import get_conn
+    rows = get_conn().execute(
+        "SELECT * FROM jobs ORDER BY created_at"
+    ).fetchall()
+    return [_row_to_job(r) for r in rows]
 
 
 def _update(job: Job) -> None:
+    _ensure_migrated()
     with _lock:
-        all_jobs = _load()
-        for i, d in enumerate(all_jobs):
-            if d.get("id") == job.id:
-                all_jobs[i] = job.to_dict()
-                _save(all_jobs)
-                return
-        all_jobs.append(job.to_dict())
-        _save(all_jobs)
+        _persist(job)
+        _prune_to_max()
 
 
 # ── Public API ───────────────────────────────────────────────────────────────
@@ -315,19 +413,31 @@ def cancel(job_id: str) -> None:
 # ── Query ────────────────────────────────────────────────────────────────────
 
 def get(job_id: str) -> Optional[Job]:
-    for d in _load():
-        if d.get("id") == job_id:
-            return Job.from_dict(d)
-    return None
+    _ensure_migrated()
+    from cc_daemon.schema import get_conn
+    row = get_conn().execute(
+        "SELECT * FROM jobs WHERE id=?", (job_id,)
+    ).fetchone()
+    return _row_to_job(row) if row is not None else None
 
 
 def list_recent(n: int = 10) -> list[Job]:
     """Return last N jobs, newest first."""
-    return [Job.from_dict(d) for d in reversed(_load())][:n]
+    _ensure_migrated()
+    from cc_daemon.schema import get_conn
+    rows = get_conn().execute(
+        "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?", (n,)
+    ).fetchall()
+    return [_row_to_job(r) for r in rows]
 
 
 def list_running() -> list[Job]:
-    return [Job.from_dict(d) for d in _load() if d.get("status") == "running"]
+    _ensure_migrated()
+    from cc_daemon.schema import get_conn
+    rows = get_conn().execute(
+        "SELECT * FROM jobs WHERE status='running' ORDER BY started_at"
+    ).fetchall()
+    return [_row_to_job(r) for r in rows]
 
 
 # ── Dashboard formatting ──────────────────────────────────────────────────────

--- a/monitor/scheduler.py
+++ b/monitor/scheduler.py
@@ -20,7 +20,9 @@ import time
 from datetime import datetime, timedelta
 from typing import Callable
 
-from monitor.store import list_subscriptions, update_last_run
+from monitor.store import (
+    list_subscriptions, update_last_run, save_report,
+)
 from monitor.fetchers import fetch
 from monitor.summarizer import summarize
 from monitor.notifier import deliver, auto_channels
@@ -99,6 +101,34 @@ def run_one(topic: str, config: dict, force: bool = False) -> str:
         report += "\n\n[Delivery errors: " + "; ".join(failed) + "]"
 
     update_last_run(topic, report)
+    # F-3: persist the full report into monitor_reports + emit a
+    # monitor_report event so SSE clients (Web UI / future bridges) see
+    # the new digest as it lands.  Both calls are best-effort — a
+    # failure in either path must not lose the in-process return value
+    # that REPL `/monitor run` is showing the user right now.
+    sent_to = [ch for ch, err in results.items() if not err]
+    report_id = ""
+    try:
+        report_id = save_report(topic, report, sent_to=sent_to)
+    except Exception:
+        pass
+    try:
+        from cc_daemon import events as _events
+        _events.get_bus().publish(
+            "monitor_report",
+            {
+                "topic":     topic,
+                "report_id": report_id,
+                "body":      report,
+                "sent_to":   sent_to,
+                "errors":    failed,
+            },
+        )
+    except Exception:
+        # If the daemon isn't running (REPL-only mode), no bus is set up
+        # — we already saved the report to monitor_reports above so the
+        # next daemon-bound subscriber will see it via list_reports.
+        pass
     return report
 
 
@@ -115,11 +145,11 @@ def _scheduler_loop(config: dict, on_report: Callable | None) -> None:
                         on_report(sub["topic"], report)
         except Exception:
             pass
-        # Sleep in 30s increments to be responsive to stop signal
-        for _ in range(60):
-            if _scheduler_stop.is_set():
-                return
-            time.sleep(30)
+        # Interruptible 60 s wait — Event.wait returns immediately when
+        # _scheduler_stop is set, so daemon shutdown doesn't have to
+        # stall up to 30 s for the scheduler thread to wake up.
+        if _scheduler_stop.wait(timeout=60):
+            return
 
 
 def start(config: dict, on_report: Callable | None = None) -> bool:

--- a/monitor/store.py
+++ b/monitor/store.py
@@ -1,90 +1,300 @@
-"""
-monitor/store.py — Persistent subscription storage.
+"""monitor/store.py — Persistent subscription storage.
 
-Subscriptions are stored in ~/.cheetahclaws/monitor_subscriptions.json.
+F-3 swapped JSON-file storage for the SQLite ``monitor_subscriptions``
+table (in the shared ``~/.cheetahclaws/sessions.db``).  Reports get a
+companion ``monitor_reports`` row.  REPL and daemon both read/write the
+same tables — there is no in-memory cache, so a subscription added in
+REPL is visible to the daemon scheduler on its next poll.
+
+Public API (unchanged from the legacy JSON store): ``list_subscriptions``,
+``get_subscription``, ``add_subscription``, ``remove_subscription``,
+``update_last_run``.  New: ``save_report`` and ``list_reports``.
+
+Migration: ``~/.cheetahclaws/monitor_subscriptions.json`` is imported
+once on first access (tracked via ``schema_meta.monitor_migrated_from_json``);
+the JSON file is kept readable for one release as fallback.
 """
 from __future__ import annotations
 
 import json
+import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Iterable, Optional
 
 STORE_PATH = Path.home() / ".cheetahclaws" / "monitor_subscriptions.json"
 
-
-def _load() -> dict:
-    if not STORE_PATH.exists():
-        return {"subscriptions": []}
-    try:
-        return json.loads(STORE_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return {"subscriptions": []}
+_MIGRATION_KEY = "monitor_migrated_from_json"
+_migration_done_in_process = False
+_migration_lock = threading.Lock()
 
 
-def _save(data: dict) -> None:
-    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    STORE_PATH.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+def _conn():
+    from cc_daemon.schema import get_conn
+    return get_conn()
 
+
+# ── One-shot JSON → SQLite migration ──────────────────────────────────────
+
+def _ensure_migrated() -> None:
+    """Idempotent import of the legacy JSON file into SQLite.
+
+    Tracked by ``schema_meta.monitor_migrated_from_json`` so subsequent
+    processes don't redo the import.  The JSON file itself is **left in
+    place** post-migration so users on the prior release can still read
+    it as fallback.
+    """
+    global _migration_done_in_process
+    if _migration_done_in_process:
+        return
+    with _migration_lock:
+        if _migration_done_in_process:
+            return
+        c = _conn()
+        row = c.execute(
+            "SELECT value FROM schema_meta WHERE key=?", (_MIGRATION_KEY,)
+        ).fetchone()
+        if row is None and STORE_PATH.exists():
+            try:
+                legacy = json.loads(STORE_PATH.read_text(encoding="utf-8"))
+            except Exception:
+                legacy = {"subscriptions": []}
+            for sub in legacy.get("subscriptions", []) or []:
+                if not isinstance(sub, dict) or "topic" not in sub:
+                    continue
+                try:
+                    _persist(sub, conn=c)
+                except Exception:
+                    continue
+            # If a legacy subscription had a last_report we mirror it as a
+            # single seed row in monitor_reports so /monitor history works
+            # right after upgrade.
+            for sub in legacy.get("subscriptions", []) or []:
+                if not isinstance(sub, dict):
+                    continue
+                last_report = sub.get("last_report")
+                if last_report and sub.get("topic"):
+                    try:
+                        _save_report_row(
+                            topic=sub["topic"],
+                            body=last_report,
+                            sent_to=sub.get("channels") or [],
+                            ts=sub.get("last_run") or _now_iso(),
+                            conn=c,
+                        )
+                    except Exception:
+                        pass
+        if row is None:
+            now = _now_iso()
+            c.execute(
+                "INSERT INTO schema_meta (key, value, updated_at) "
+                "VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET "
+                "value=excluded.value, updated_at=excluded.updated_at",
+                (_MIGRATION_KEY, "1", now),
+            )
+            c.commit()
+        _migration_done_in_process = True
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _row_to_sub(row) -> dict:
+    """Convert a sqlite3.Row to the historical dict shape callers expect."""
+    recipients = []
+    if row["recipients_json"]:
+        try:
+            recipients = json.loads(row["recipients_json"])
+        except (TypeError, ValueError):
+            recipients = []
+    cfg: dict = {}
+    if row["config_json"]:
+        try:
+            cfg = json.loads(row["config_json"])
+        except (TypeError, ValueError):
+            cfg = {}
+    return {
+        "id":          cfg.get("id", ""),  # legacy cosmetic id (if any)
+        "topic":       row["topic"],
+        "schedule":    row["schedule"],
+        "channels":    recipients,
+        "enabled":     bool(row["enabled"]),
+        "created_at":  cfg.get("created_at", ""),
+        "last_run":    row["last_run_at"],
+        "next_run":    row["next_run_at"],
+        "last_report": cfg.get("last_report_preview", ""),
+    }
+
+
+def _persist(sub: dict, *, conn=None) -> None:
+    """INSERT/UPDATE a subscription row from a legacy- or new-shape dict."""
+    c = conn if conn is not None else _conn()
+    topic = sub["topic"]
+    schedule = sub.get("schedule") or "6h"
+    channels = sub.get("channels") or []
+    enabled = 1 if sub.get("enabled", True) else 0
+    last_run = sub.get("last_run")
+    next_run = sub.get("next_run")
+    cfg = {
+        # Stash legacy/cosmetic fields the new schema doesn't carry as columns.
+        # Keeps `_row_to_sub` round-tripping the historical dict shape.
+        "id":                    sub.get("id", ""),
+        "created_at":            sub.get("created_at", ""),
+        "last_report_preview":   sub.get("last_report", "") or "",
+    }
+    c.execute(
+        "INSERT INTO monitor_subscriptions "
+        "  (topic, schedule, enabled, last_run_at, next_run_at, "
+        "   recipients_json, config_json) "
+        "VALUES (?,?,?,?,?,?,?) "
+        "ON CONFLICT(topic) DO UPDATE SET "
+        "  schedule=excluded.schedule, "
+        "  enabled=excluded.enabled, "
+        "  last_run_at=COALESCE(excluded.last_run_at, monitor_subscriptions.last_run_at), "
+        "  next_run_at=COALESCE(excluded.next_run_at, monitor_subscriptions.next_run_at), "
+        "  recipients_json=excluded.recipients_json, "
+        "  config_json=excluded.config_json",
+        (topic, schedule, enabled, last_run, next_run,
+         json.dumps(channels, ensure_ascii=False),
+         json.dumps(cfg, ensure_ascii=False)),
+    )
+    if conn is None:
+        c.commit()
+
+
+# ── Public API ────────────────────────────────────────────────────────────
 
 def list_subscriptions() -> list[dict]:
-    return _load().get("subscriptions", [])
+    _ensure_migrated()
+    rows = _conn().execute(
+        "SELECT * FROM monitor_subscriptions ORDER BY topic"
+    ).fetchall()
+    return [_row_to_sub(r) for r in rows]
 
 
-def get_subscription(topic: str) -> dict | None:
-    for s in list_subscriptions():
-        if s["topic"] == topic:
-            return s
-    return None
+def get_subscription(topic: str) -> Optional[dict]:
+    _ensure_migrated()
+    row = _conn().execute(
+        "SELECT * FROM monitor_subscriptions WHERE topic=?", (topic,)
+    ).fetchone()
+    return _row_to_sub(row) if row is not None else None
 
 
 def add_subscription(topic: str, schedule: str = "daily",
-                     channels: list[str] | None = None) -> dict:
-    """Add or update a subscription. Returns the subscription dict."""
-    data = _load()
-    subs = data.setdefault("subscriptions", [])
-
-    # Update if exists
-    for s in subs:
-        if s["topic"] == topic:
-            s["schedule"] = schedule
-            if channels is not None:
-                s["channels"] = channels
-            _save(data)
-            return s
-
-    sub = {
-        "id": uuid.uuid4().hex[:8],
-        "topic": topic,
-        "schedule": schedule,
-        "channels": channels or [],
-        "created_at": datetime.now().isoformat(),
-        "last_run": None,
-        "next_run": None,
-        "last_report": None,
-    }
-    subs.append(sub)
-    _save(data)
-    return sub
+                     channels: Optional[list[str]] = None) -> dict:
+    """Add or update a subscription.  Returns the full subscription dict."""
+    _ensure_migrated()
+    existing = get_subscription(topic)
+    if existing is None:
+        sub = {
+            "id":          uuid.uuid4().hex[:8],
+            "topic":       topic,
+            "schedule":    schedule,
+            "channels":    channels or [],
+            "enabled":     True,
+            "created_at":  _now_iso(),
+            "last_run":    None,
+            "next_run":    None,
+            "last_report": "",
+        }
+    else:
+        sub = dict(existing)
+        sub["schedule"] = schedule
+        if channels is not None:
+            sub["channels"] = channels
+    _persist(sub)
+    return get_subscription(topic) or sub
 
 
 def remove_subscription(topic: str) -> bool:
-    data = _load()
-    before = len(data.get("subscriptions", []))
-    data["subscriptions"] = [s for s in data.get("subscriptions", [])
-                              if s["topic"] != topic]
-    if len(data["subscriptions"]) < before:
-        _save(data)
-        return True
-    return False
+    _ensure_migrated()
+    c = _conn()
+    cur = c.execute(
+        "DELETE FROM monitor_subscriptions WHERE topic=?", (topic,)
+    )
+    c.commit()
+    return cur.rowcount > 0
 
 
 def update_last_run(topic: str, report: str) -> None:
-    data = _load()
-    now = datetime.now().isoformat()
-    for s in data.get("subscriptions", []):
-        if s["topic"] == topic:
-            s["last_run"] = now
-            s["last_report"] = report[:500]  # preview
-            break
-    _save(data)
+    _ensure_migrated()
+    c = _conn()
+    # Stash a 500-char preview of the latest report on the row itself
+    # (mirrors the legacy behaviour); full body lives in monitor_reports.
+    row = c.execute(
+        "SELECT config_json FROM monitor_subscriptions WHERE topic=?",
+        (topic,),
+    ).fetchone()
+    cfg: dict[str, Any] = {}
+    if row and row["config_json"]:
+        try:
+            cfg = json.loads(row["config_json"])
+        except (TypeError, ValueError):
+            cfg = {}
+    cfg["last_report_preview"] = (report or "")[:500]
+    c.execute(
+        "UPDATE monitor_subscriptions "
+        "SET last_run_at=?, config_json=? WHERE topic=?",
+        (_now_iso(), json.dumps(cfg, ensure_ascii=False), topic),
+    )
+    c.commit()
+
+
+# ── Reports ────────────────────────────────────────────────────────────────
+
+def _save_report_row(*, topic: str, body: str, sent_to: Iterable[str],
+                     ts: Optional[str] = None, conn=None) -> str:
+    c = conn if conn is not None else _conn()
+    rid = uuid.uuid4().hex[:12]
+    c.execute(
+        "INSERT INTO monitor_reports (id, topic, ts, body, sent_to_json) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (rid, topic, ts or _now_iso(), body or "",
+         json.dumps(list(sent_to or []), ensure_ascii=False)),
+    )
+    if conn is None:
+        c.commit()
+    return rid
+
+
+def save_report(topic: str, body: str,
+                sent_to: Optional[Iterable[str]] = None) -> str:
+    """Persist a generated monitor report.  Returns the new report id."""
+    _ensure_migrated()
+    return _save_report_row(topic=topic, body=body, sent_to=sent_to or [])
+
+
+def list_reports(topic: Optional[str] = None, *, limit: int = 20) -> list[dict]:
+    """Most-recent reports, optionally filtered by topic."""
+    _ensure_migrated()
+    c = _conn()
+    if topic is None:
+        rows = c.execute(
+            "SELECT id, topic, ts, body, sent_to_json FROM monitor_reports "
+            "ORDER BY ts DESC LIMIT ?", (limit,)
+        ).fetchall()
+    else:
+        rows = c.execute(
+            "SELECT id, topic, ts, body, sent_to_json FROM monitor_reports "
+            "WHERE topic=? ORDER BY ts DESC LIMIT ?", (topic, limit)
+        ).fetchall()
+    out = []
+    for r in rows:
+        sent_to = []
+        if r["sent_to_json"]:
+            try:
+                sent_to = json.loads(r["sent_to_json"])
+            except (TypeError, ValueError):
+                sent_to = []
+        out.append({
+            "id":      r["id"],
+            "topic":   r["topic"],
+            "ts":      r["ts"],
+            "body":    r["body"] or "",
+            "sent_to": sent_to,
+        })
+    return out

--- a/tests/e2e_daemon_skeleton.py
+++ b/tests/e2e_daemon_skeleton.py
@@ -384,6 +384,36 @@ def test_sessions_db_initialised_on_first_serve(tmp_path):
         assert t in names, f"missing table after serve: {t}"
 
 
+def test_monitor_subscribe_via_rpc_survives_daemon_restart(tmp_path):
+    """F-3 headline:  /monitor subscribe via RPC persists into SQLite,
+    daemon stops, daemon starts again, subscription is still listed."""
+    proc1, addr1, token1 = _start_daemon(tmp_path)
+    try:
+        status, body = _post_rpc(addr1, token1, "monitor.subscribe",
+                                  params={"topic": "arxiv",
+                                          "schedule": "daily",
+                                          "channels": ["console"]})
+        assert status == 200
+        assert body["result"]["topic"] == "arxiv"
+
+        status, body = _post_rpc(addr1, token1, "monitor.list")
+        assert status == 200
+        topics = {s["topic"] for s in body["result"]["subscriptions"]}
+        assert "arxiv" in topics
+    finally:
+        _stop_daemon(proc1, addr1, token1)
+
+    proc2, addr2, token2 = _start_daemon(tmp_path)
+    try:
+        status, body = _post_rpc(addr2, token2, "monitor.list")
+        assert status == 200
+        topics = {s["topic"] for s in body["result"]["subscriptions"]}
+        assert "arxiv" in topics, \
+            f"subscription did not survive restart: {topics}"
+    finally:
+        _stop_daemon(proc2, addr2, token2)
+
+
 def test_events_persist_in_sqlite_across_daemon_restart(tmp_path):
     """Publish events on daemon A (echo.ping fires `ping_received`),
     stop daemon A, start daemon B against the same data dir, and

--- a/tests/e2e_daemon_skeleton.py
+++ b/tests/e2e_daemon_skeleton.py
@@ -302,3 +302,134 @@ def test_daemon_rotate_token_changes_file(daemon_proc):
     assert rc == 0
     assert "rotated" in stdout.lower()
     assert token_path.read_text().strip() != token
+
+
+# ── F-2: SQLite persistence + cross-restart replay ────────────────────────
+
+def _start_daemon(home: Path, *, wait_s: float = 10.0) -> tuple[subprocess.Popen, str, str]:
+    """Boot a daemon under *home*; return (proc, address, token)."""
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(home / "xdg")
+    proc = subprocess.Popen(
+        [sys.executable, "cheetahclaws.py", "serve",
+         "--listen", "tcp://127.0.0.1:0"],
+        cwd=str(REPO_ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    discovery_file = home / ".cheetahclaws" / "daemon.json"
+    token_file = home / ".cheetahclaws" / "daemon_token"
+    deadline = time.monotonic() + wait_s
+    info = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            pytest.fail(
+                "daemon exited before binding\n"
+                f"stdout: {stdout.decode('utf-8', 'replace')}\n"
+                f"stderr: {stderr.decode('utf-8', 'replace')}"
+            )
+        if discovery_file.exists() and token_file.exists():
+            try:
+                info = json.loads(discovery_file.read_text(encoding="utf-8"))
+                break
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.1)
+    if info is None:
+        proc.terminate()
+        proc.wait(timeout=5)
+        pytest.fail("daemon did not write discovery file in time")
+    return proc, info["address"], token_file.read_text(encoding="utf-8").strip()
+
+
+def _stop_daemon(proc: subprocess.Popen, address: str, token: str) -> None:
+    if proc.poll() is None:
+        try:
+            _post_rpc(address, token, "system.shutdown")
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def test_sessions_db_initialised_on_first_serve(tmp_path):
+    """F-2 schema: cheetahclaws serve initialises ~/.cheetahclaws/sessions.db
+    with the daemon tables before accepting any RPC."""
+    proc, address, token = _start_daemon(tmp_path)
+    try:
+        # Hit ping so we know the daemon is fully up.
+        status, _ = _post_rpc(address, token, "system.ping")
+        assert status == 200
+    finally:
+        _stop_daemon(proc, address, token)
+
+    db_path = tmp_path / ".cheetahclaws" / "sessions.db"
+    assert db_path.exists()
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        names = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+    finally:
+        conn.close()
+    for t in ("daemon_events", "agent_runs", "agent_iterations", "jobs",
+              "monitor_subscriptions", "monitor_reports", "bridges",
+              "schema_meta"):
+        assert t in names, f"missing table after serve: {t}"
+
+
+def test_events_persist_in_sqlite_across_daemon_restart(tmp_path):
+    """Publish events on daemon A (echo.ping fires `ping_received`),
+    stop daemon A, start daemon B against the same data dir, and
+    verify GET /events?since=0 replays the events from SQLite.
+    This is the headline F-2 user-visible win for SSE clients
+    (Web UI / future bridges) that survive daemon restarts.
+    """
+    from cc_daemon import API_VERSION, API_VERSION_HEADER
+
+    # Boot A, publish a few events via echo.ping.
+    proc1, addr1, token1 = _start_daemon(tmp_path)
+    try:
+        for i in range(3):
+            status, body = _post_rpc(addr1, token1, "echo.ping",
+                                     params={"i": i})
+            assert status == 200
+            assert body["result"]["pong"] is True
+    finally:
+        _stop_daemon(proc1, addr1, token1)
+
+    # Boot B against the same HOME → same sessions.db.
+    proc2, addr2, token2 = _start_daemon(tmp_path)
+    try:
+        host, port_s = addr2.rsplit(":", 1)
+        conn = http.client.HTTPConnection(host, int(port_s), timeout=10.0)
+        conn.request("GET", "/events?since=0",
+                     headers={"Authorization": f"Bearer {token2}",
+                              API_VERSION_HEADER: API_VERSION})
+        resp = conn.getresponse()
+        assert resp.status == 200
+        # Read enough to capture all replayed events; daemon may also
+        # emit a heartbeat — bail when we've seen all 3 pings or 5 s pass.
+        deadline = time.monotonic() + 5.0
+        buf = b""
+        while time.monotonic() < deadline:
+            chunk = resp.read(1)
+            if not chunk:
+                break
+            buf += chunk
+            if buf.count(b"event: ping_received") >= 3:
+                break
+        conn.close()
+    finally:
+        _stop_daemon(proc2, addr2, token2)
+
+    text = buf.decode("utf-8", errors="replace")
+    assert text.count("event: ping_received") >= 3, \
+        f"missing replayed events:\n{text[:500]}"
+

--- a/tests/test_cc_daemon_events_sqlite.py
+++ b/tests/test_cc_daemon_events_sqlite.py
@@ -1,0 +1,194 @@
+"""F-2 tests for cc_daemon/events.py SQLite-backed bus.
+
+The spike-era ring-buffer tests live in test_daemon_spike.py; this file
+exercises the new persistence + retention + cross-restart behaviour.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cc_daemon import events, schema
+
+
+@pytest.fixture(autouse=True)
+def _per_test_db(tmp_path: Path):
+    """Each test gets a private sessions.db so daemon_events doesn't bleed
+    across tests (the spike's in-memory ring auto-isolated; SQLite doesn't)."""
+    schema.set_db_path(tmp_path / "sessions.db")
+    schema._local.conn = None
+    events.reset_bus_for_tests()
+    yield
+    schema._local.conn = None
+    schema.set_db_path(schema.get_default_db_path())  # restore default
+
+
+# ── Persistence: events written to daemon_events ──────────────────────────
+
+def test_publish_persists_to_daemon_events_table():
+    bus = events.EventBus()
+    eid = bus.publish("text_chunk", {"text": "hello"})
+    conn = schema.get_conn()
+    row = conn.execute(
+        "SELECT id, kind, payload_json FROM daemon_events WHERE id=?",
+        (eid,),
+    ).fetchone()
+    assert row is not None
+    assert row[1] == "text_chunk"
+    assert "hello" in row[2]
+
+
+def test_publish_returns_monotonic_ids():
+    bus = events.EventBus()
+    a = bus.publish("k", {"i": 1})
+    b = bus.publish("k", {"i": 2})
+    assert b == a + 1
+
+
+def test_replay_since_reads_from_sqlite():
+    bus = events.EventBus()
+    bus.publish("a", {"n": 0})
+    bus.publish("a", {"n": 1})
+    bus.publish("a", {"n": 2})
+    out = list(bus.replay_since(1))
+    # No gap, ids 2 and 3
+    assert all(e["type"] != "gap" for e in out)
+    assert [e["data"]["n"] for e in out] == [1, 2]
+
+
+def test_replay_zero_includes_all():
+    bus = events.EventBus()
+    bus.publish("k", {"n": 1})
+    bus.publish("k", {"n": 2})
+    out = list(bus.replay_since(0))
+    assert [e["data"]["n"] for e in out] == [1, 2]
+
+
+def test_originator_round_trips_through_sqlite():
+    bus = events.EventBus()
+    bus.publish("permission_request", {"tool": "Bash"},
+                originator={"client_id": "abc", "client_kind": "repl"})
+    out = list(bus.replay_since(0))
+    assert out[0]["originator"] == {"client_id": "abc", "client_kind": "repl"}
+
+
+# ── Retention: prune by row count ─────────────────────────────────────────
+
+def test_retention_rows_prunes_oldest():
+    bus = events.EventBus(retention_rows=3, prune_every_n=1)
+    for i in range(10):
+        bus.publish("k", {"i": i})
+    conn = schema.get_conn()
+    count = conn.execute("SELECT COUNT(*) FROM daemon_events").fetchone()[0]
+    assert count == 3
+    # The surviving rows are the newest 3 (ids 8, 9, 10)
+    ids = [r[0] for r in conn.execute(
+        "SELECT id FROM daemon_events ORDER BY id"
+    ).fetchall()]
+    assert ids == [8, 9, 10]
+
+
+def test_retention_hours_prunes_old_rows(monkeypatch):
+    bus = events.EventBus(retention_hours=0.0001, prune_every_n=1)  # ~360 ms
+    bus.publish("k", {"i": 1})
+    time.sleep(0.5)
+    bus.publish("k", {"i": 2})  # this triggers the prune; old row evicted
+    conn = schema.get_conn()
+    rows = [r[0] for r in conn.execute(
+        "SELECT id FROM daemon_events ORDER BY id"
+    ).fetchall()]
+    assert 1 not in rows
+    assert 2 in rows
+
+
+# ── Gap detection ─────────────────────────────────────────────────────────
+
+def test_gap_emitted_when_since_is_pre_retention_window():
+    bus = events.EventBus(retention_rows=3, prune_every_n=1)
+    for i in range(10):
+        bus.publish("k", {"i": i})
+    out = list(bus.replay_since(1))
+    assert out[0]["type"] == "gap"
+    assert out[0]["data"]["reason"] == "retention_prune"
+    assert out[0]["data"]["missed_from"] == 2
+    assert all(e["id"] > 1 for e in out[1:])
+
+
+def test_no_gap_when_since_is_in_window():
+    bus = events.EventBus(retention_rows=10, prune_every_n=100)
+    for _ in range(5):
+        bus.publish("k", {})
+    out = list(bus.replay_since(2))
+    assert all(e["type"] != "gap" for e in out)
+
+
+def test_no_gap_on_empty_table():
+    bus = events.EventBus()
+    out = list(bus.replay_since(0))
+    assert out == []
+
+
+# ── Subscribers receive live events while persistence happens ─────────────
+
+def test_subscriber_gets_published_event_live():
+    bus = events.EventBus()
+    sub = bus.subscribe()
+    eid = bus.publish("hello", {"x": 1})
+    evt = sub.get(timeout=1.0)
+    assert evt["id"] == eid
+    assert evt["type"] == "hello"
+    assert evt["data"] == {"x": 1}
+    bus.unsubscribe(sub)
+
+
+def test_unsubscribe_drops_subscriber():
+    bus = events.EventBus()
+    sub = bus.subscribe()
+    assert bus.subscriber_count() == 1
+    bus.unsubscribe(sub)
+    assert bus.subscriber_count() == 0
+
+
+# ── reset_bus_for_tests truncates the table ───────────────────────────────
+
+def test_reset_bus_clears_daemon_events():
+    bus = events.EventBus()
+    bus.publish("k", {})
+    bus.publish("k", {})
+    events.reset_bus_for_tests()
+    conn = schema.get_conn()
+    count = conn.execute("SELECT COUNT(*) FROM daemon_events").fetchone()[0]
+    assert count == 0
+
+
+def test_reset_bus_resets_id_sequence():
+    bus = events.EventBus()
+    bus.publish("k", {})
+    bus.publish("k", {})
+    events.reset_bus_for_tests()
+    bus2 = events.EventBus()
+    new_id = bus2.publish("k", {})
+    assert new_id == 1
+
+
+# ── Cross-restart simulation: drop the EventBus instance, recreate ────────
+
+def test_replay_works_after_bus_recreate():
+    """Simulates daemon restart: drop EventBus, recreate against same DB,
+    SSE client that survived the restart can still ?since=N up."""
+    bus1 = events.EventBus()
+    bus1.publish("k", {"n": 1})
+    bus1.publish("k", {"n": 2})
+    bus1.publish("k", {"n": 3})
+
+    # Drop and recreate (simulates daemon process restart)
+    bus2 = events.EventBus()
+    out = list(bus2.replay_since(1))
+    assert [e["data"]["n"] for e in out] == [2, 3]
+    assert all(e["type"] != "gap" for e in out)

--- a/tests/test_cc_daemon_monitor_methods.py
+++ b/tests/test_cc_daemon_monitor_methods.py
@@ -1,0 +1,181 @@
+"""F-3 unit tests for cc_daemon/monitor_methods.py — RPC wrappers."""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import monitor.store as store
+import monitor.scheduler as scheduler
+from cc_daemon import events, monitor_methods, schema
+from cc_daemon.rpc import CallContext, RpcRegistry
+
+
+# ── Fakes / fixtures ──────────────────────────────────────────────────────
+
+class _FakeState:
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or {}
+        self.shutdown_event = threading.Event()
+
+
+def _ctx(client_id: str = "test-client") -> CallContext:
+    return CallContext(client_id=client_id, transport="tcp", api_version="0")
+
+
+def _call(registry: RpcRegistry, method: str, params=None) -> dict:
+    envelope = {"jsonrpc": "2.0", "id": 1, "method": method,
+                "params": params or {}}
+    response, _status = registry.dispatch(envelope, _ctx())
+    return response
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(store, "STORE_PATH",
+                        tmp_path / "monitor_subscriptions.json")
+    schema.set_db_path(tmp_path / "sessions.db")
+    schema._local.conn = None
+    store._migration_done_in_process = False
+    events.reset_bus_for_tests()
+    # Stub fetch/summarize/deliver so monitor.run doesn't hit network.
+    monkeypatch.setattr(scheduler, "fetch", lambda _t: "raw")
+    monkeypatch.setattr(scheduler, "summarize", lambda _r, _c: "SUMMARY")
+    monkeypatch.setattr(scheduler, "deliver",
+                        lambda _r, channels, _c: {ch: "" for ch in channels})
+    monkeypatch.setattr(scheduler, "auto_channels", lambda _c: ["console"])
+    yield
+    schema._local.conn = None
+    schema.set_db_path(schema.get_default_db_path())
+
+
+# ── monitor.subscribe ─────────────────────────────────────────────────────
+
+def test_subscribe_creates_subscription():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.subscribe",
+                 {"topic": "arxiv", "schedule": "daily",
+                  "channels": ["console"]})
+    assert resp["result"]["topic"] == "arxiv"
+    assert resp["result"]["schedule"] == "daily"
+    # Persisted in SQLite
+    assert store.get_subscription("arxiv") is not None
+
+
+def test_subscribe_is_upsert():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    _call(registry, "monitor.subscribe",
+          {"topic": "arxiv", "schedule": "daily"})
+    resp = _call(registry, "monitor.subscribe",
+                 {"topic": "arxiv", "schedule": "6h",
+                  "channels": ["telegram"]})
+    assert resp["result"]["schedule"] == "6h"
+    assert len(store.list_subscriptions()) == 1
+
+
+def test_subscribe_rejects_missing_topic():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.subscribe", {})
+    assert "error" in resp
+
+
+def test_subscribe_rejects_non_list_channels():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.subscribe",
+                 {"topic": "arxiv", "channels": "telegram"})  # str, not list
+    assert "error" in resp
+
+
+# ── monitor.unsubscribe ──────────────────────────────────────────────────
+
+def test_unsubscribe_removes_existing():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    store.add_subscription("arxiv", schedule="daily")
+    resp = _call(registry, "monitor.unsubscribe", {"topic": "arxiv"})
+    assert resp["result"] == {"topic": "arxiv", "removed": True}
+    assert store.get_subscription("arxiv") is None
+
+
+def test_unsubscribe_idempotent_on_missing():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.unsubscribe", {"topic": "never-was"})
+    assert resp["result"] == {"topic": "never-was", "removed": False}
+
+
+# ── monitor.list ─────────────────────────────────────────────────────────
+
+def test_list_returns_all_subscriptions():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    store.add_subscription("arxiv", schedule="daily")
+    store.add_subscription("news", schedule="6h", channels=["telegram"])
+    resp = _call(registry, "monitor.list", {})
+    topics = {s["topic"] for s in resp["result"]["subscriptions"]}
+    assert topics == {"arxiv", "news"}
+
+
+def test_list_when_empty_returns_empty_array():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.list", {})
+    assert resp["result"]["subscriptions"] == []
+
+
+# ── monitor.run ──────────────────────────────────────────────────────────
+
+def test_run_returns_report_and_persists():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState({"model": "stub"}))
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    resp = _call(registry, "monitor.run", {"topic": "arxiv"})
+    assert "SUMMARY" in resp["result"]["report"]
+    assert resp["result"]["topic"] == "arxiv"
+    assert len(store.list_reports("arxiv")) == 1
+
+
+def test_run_rejects_missing_topic():
+    registry = RpcRegistry()
+    monitor_methods.register(registry, _FakeState())
+    resp = _call(registry, "monitor.run", {})
+    assert "error" in resp
+
+
+def test_run_publishes_monitor_report_event():
+    registry = RpcRegistry()
+    state = _FakeState({"model": "stub"})
+    monitor_methods.register(registry, state)
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    bus = events.get_bus()
+    sub = bus.subscribe()
+    try:
+        _call(registry, "monitor.run", {"topic": "arxiv"})
+        evt = sub.get(timeout=2.0)
+        assert evt["type"] == "monitor_report"
+        assert evt["data"]["topic"] == "arxiv"
+    finally:
+        bus.unsubscribe(sub)
+
+
+# ── Coexistence with other registered methods ───────────────────────────
+
+def test_register_does_not_clash_with_system_methods():
+    from cc_daemon import system_methods
+    registry = RpcRegistry()
+    system_methods.register(registry, _FakeState())
+    monitor_methods.register(registry, _FakeState())
+    methods = registry.methods()
+    for m in ("system.ping", "system.shutdown",
+               "monitor.subscribe", "monitor.unsubscribe",
+               "monitor.list", "monitor.run"):
+        assert m in methods

--- a/tests/test_cc_daemon_schema.py
+++ b/tests/test_cc_daemon_schema.py
@@ -1,0 +1,211 @@
+"""Tests for cc_daemon/schema.py — additive tables + idempotent init."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cc_daemon import schema
+
+
+# ── Idempotent init ────────────────────────────────────────────────────────
+
+EXPECTED_TABLES = {
+    "schema_meta",
+    "daemon_events",
+    "agent_runs",
+    "agent_iterations",
+    "jobs",
+    "monitor_subscriptions",
+    "monitor_reports",
+    "bridges",
+}
+
+
+def _table_names(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def test_init_creates_all_expected_tables(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    present = _table_names(db)
+    for t in EXPECTED_TABLES:
+        assert t in present, f"missing table: {t}"
+
+
+def test_init_is_idempotent(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    schema.init_schema(db)  # must not raise
+    schema.init_schema(db)
+    # Schema version row remains a single entry.
+    conn = sqlite3.connect(str(db))
+    try:
+        rows = conn.execute(
+            "SELECT key, value FROM schema_meta WHERE key='schema_version'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0][1] == str(schema.CURRENT_SCHEMA_VERSION)
+
+
+def test_init_records_schema_version(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    assert schema.get_schema_version(db) == schema.CURRENT_SCHEMA_VERSION
+
+
+def test_get_schema_version_on_virgin_db(tmp_path: Path):
+    db = tmp_path / "absent.db"
+    assert schema.get_schema_version(db) is None
+
+
+def test_init_stamps_updated_at(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT updated_at FROM schema_meta WHERE key='schema_version'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    # ISO 8601 with Z suffix
+    ts = row[0]
+    assert ts.endswith("Z") and "T" in ts
+
+
+# ── Coexistence with session_store ────────────────────────────────────────
+
+def test_init_does_not_drop_existing_sessions_table(tmp_path: Path):
+    """session_store.py creates `sessions` + `sessions_fts`. Daemon init
+    must not disturb them."""
+    db = tmp_path / "sessions.db"
+    # Stand up a sessions table the way session_store would.
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.executescript("""
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, title TEXT, model TEXT,
+                saved_at TEXT NOT NULL, turn_count INTEGER,
+                input_tokens INTEGER, output_tokens INTEGER,
+                messages TEXT NOT NULL
+            );
+            CREATE VIRTUAL TABLE sessions_fts USING fts5(
+                id, title, content, tokenize='unicode61'
+            );
+            INSERT INTO sessions (id, saved_at, messages)
+                VALUES ('test-session', '2026-01-01 00:00:00', '[]');
+        """)
+        conn.commit()
+    finally:
+        conn.close()
+
+    schema.init_schema(db)
+
+    # sessions row still present + new daemon tables alongside.
+    conn = sqlite3.connect(str(db))
+    try:
+        sess_count = conn.execute(
+            "SELECT COUNT(*) FROM sessions"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert sess_count == 1
+
+    present = _table_names(db)
+    assert "sessions" in present
+    assert "sessions_fts" in present
+    for t in EXPECTED_TABLES:
+        assert t in present
+
+
+# ── Connection accessor ────────────────────────────────────────────────────
+
+def test_get_conn_returns_same_conn_per_thread(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(schema, "_db_path", tmp_path / "sessions.db")
+    schema._local.conn = None  # reset thread-local
+    a = schema.get_conn()
+    b = schema.get_conn()
+    assert a is b
+
+
+def test_get_conn_auto_inits_schema(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(schema, "_db_path", tmp_path / "sessions.db")
+    schema._local.conn = None
+    conn = schema.get_conn()
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    names = {r[0] for r in rows}
+    for t in EXPECTED_TABLES:
+        assert t in names
+
+
+def test_set_db_path_drops_stale_thread_conn(tmp_path: Path, monkeypatch):
+    db1 = tmp_path / "first.db"
+    db2 = tmp_path / "second.db"
+    schema.set_db_path(db1)
+    schema._local.conn = None
+    conn1 = schema.get_conn()
+    schema.set_db_path(db2)
+    conn2 = schema.get_conn()
+    assert conn1 is not conn2
+
+
+# ── Schema-shape sanity (catches accidental column drift) ─────────────────
+
+def test_daemon_events_columns(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in
+                conn.execute("PRAGMA table_info(daemon_events)").fetchall()}
+    finally:
+        conn.close()
+    assert {"id", "ts", "kind", "payload_json"} <= cols
+
+
+def test_jobs_columns(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in
+                conn.execute("PRAGMA table_info(jobs)").fetchall()}
+    finally:
+        conn.close()
+    expected = {"id", "title", "prompt", "source", "status", "created_at",
+                "started_at", "done_at", "duration_s", "steps_json",
+                "step_count", "current_step", "result", "error", "retry_of"}
+    assert expected <= cols
+
+
+def test_monitor_subscriptions_columns(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    schema.init_schema(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in
+                conn.execute("PRAGMA table_info(monitor_subscriptions)").fetchall()}
+    finally:
+        conn.close()
+    expected = {"topic", "schedule", "enabled", "last_run_at",
+                "next_run_at", "recipients_json", "config_json"}
+    assert expected <= cols

--- a/tests/test_daemon_spike.py
+++ b/tests/test_daemon_spike.py
@@ -104,21 +104,30 @@ def _rpc(host, port, token, method, params, *, version=API_VERSION,
 
 
 def test_ring_buffer_overflow_emits_gap():
-    bus = EventBus(ring_cap=5)
+    """F-2: ring → SQLite swap.  Original spike test exercised the bounded
+    in-memory ring (``ring_cap=5``); the F-2 SQLite-backed bus uses
+    age + row retention instead.  Same intent: when the bus has evicted
+    events the caller wants, ``replay_since`` yields a synthetic ``gap``
+    so SSE clients can resync.  ``ring_cap`` is still accepted on the
+    constructor for backward compat but ignored — retention drives
+    eviction now.
+    """
+    events.reset_bus_for_tests()
+    bus = EventBus(retention_rows=5, prune_every_n=1)
     for i in range(10):
         bus.publish("t", {"i": i})
-    # Asking for events after id=1 should report a gap because ring kept ids 6..10.
     out = list(bus.replay_since(1))
     assert out[0]["type"] == "gap"
     assert out[0]["data"]["missed_from"] == 2
-    # The remaining replayed events all have id > since
     assert all(e["id"] > 1 for e in out[1:])
-    # And include the most recent
     assert out[-1]["data"]["i"] == 9
 
 
 def test_ring_buffer_no_gap_within_window():
-    bus = EventBus(ring_cap=10)
+    """F-2: SQLite-backed bus, retention high enough that nothing's evicted.
+    Replay should be exact and gap-free."""
+    events.reset_bus_for_tests()
+    bus = EventBus(retention_rows=10, prune_every_n=1)
     for i in range(5):
         bus.publish("t", {"i": i})
     out = list(bus.replay_since(2))

--- a/tests/test_jobs_sqlite.py
+++ b/tests/test_jobs_sqlite.py
@@ -1,0 +1,195 @@
+"""F-2 tests for jobs.py — SQLite backing + JSON-file migration."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import jobs
+from cc_daemon import schema
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db_and_jobs_path(tmp_path: Path, monkeypatch):
+    """Each test gets a private sessions.db AND its own jobs.json path
+    so the legacy migration logic doesn't touch the real user file."""
+    monkeypatch.setattr(jobs, "_JOBS_PATH", tmp_path / "jobs.json")
+    schema.set_db_path(tmp_path / "sessions.db")
+    schema._local.conn = None
+    # Reset migration sentinel so each test re-runs migration
+    jobs._migration_done_in_process = False
+    yield
+    schema._local.conn = None
+    schema.set_db_path(schema.get_default_db_path())
+
+
+# ── Roundtrip ──────────────────────────────────────────────────────────────
+
+def test_create_persists_to_sqlite():
+    j = jobs.create("hello world", source="test")
+    conn = schema.get_conn()
+    row = conn.execute(
+        "SELECT id, prompt, status FROM jobs WHERE id=?", (j.id,)
+    ).fetchone()
+    assert row is not None
+    assert row["prompt"] == "hello world"
+    assert row["status"] == "queued"
+
+
+def test_get_returns_persisted_job():
+    j = jobs.create("foo", source="test")
+    fetched = jobs.get(j.id)
+    assert fetched is not None
+    assert fetched.id == j.id
+    assert fetched.prompt == "foo"
+
+
+def test_lifecycle_updates_status_in_sqlite():
+    j = jobs.create("lifecycle", source="test")
+    jobs.start(j.id)
+    assert jobs.get(j.id).status == "running"
+    jobs.complete(j.id, result_preview="done")
+    assert jobs.get(j.id).status == "done"
+
+
+def test_steps_are_round_tripped_as_json():
+    j = jobs.create("with steps", source="test")
+    jobs.add_step(j.id, "Bash", "ls -la")
+    jobs.finish_step(j.id, "Bash", "5 files")
+    fetched = jobs.get(j.id)
+    assert any(s.get("name") == "Bash" for s in fetched.steps)
+
+
+def test_list_recent_orders_newest_first():
+    j1 = jobs.create("one", source="t")
+    j2 = jobs.create("two", source="t")
+    j3 = jobs.create("three", source="t")
+    recent = jobs.list_recent(10)
+    assert [r.id for r in recent[:3]] == [j3.id, j2.id, j1.id]
+
+
+def test_list_running_only_returns_running():
+    j1 = jobs.create("a", source="t"); jobs.start(j1.id)
+    j2 = jobs.create("b", source="t")  # stays queued
+    j3 = jobs.create("c", source="t"); jobs.start(j3.id); jobs.complete(j3.id)
+    running = jobs.list_running()
+    assert {r.id for r in running} == {j1.id}
+
+
+def test_max_jobs_pruning_keeps_recent():
+    """The legacy JSON storage capped at 100; SQLite mirror should too."""
+    original = jobs._MAX_JOBS
+    try:
+        jobs._MAX_JOBS = 5
+        for i in range(10):
+            jobs.create(f"job-{i}", source="t")
+        recent = jobs.list_recent(20)
+        assert len(recent) == 5
+        # Newest 5 survived
+        assert [r.prompt for r in recent] == [f"job-{i}" for i in (9, 8, 7, 6, 5)]
+    finally:
+        jobs._MAX_JOBS = original
+
+
+# ── JSON migration ────────────────────────────────────────────────────────
+
+def test_migration_imports_legacy_json_jobs(tmp_path):
+    legacy = [
+        {"id": "abc123", "title": "old job", "prompt": "old prompt",
+         "status": "done", "source": "telegram", "steps": [],
+         "step_count": 0, "current_step": "", "result": "old result",
+         "error": "", "created_at": "2026-04-01T10:00:00",
+         "started_at": "2026-04-01T10:00:01",
+         "done_at": "2026-04-01T10:00:05",
+         "duration_s": 4.0, "retry_of": ""},
+        {"id": "def456", "title": "another", "prompt": "another prompt",
+         "status": "failed", "source": "console", "steps": [],
+         "step_count": 0, "current_step": "", "result": "",
+         "error": "boom", "created_at": "2026-04-02T11:00:00",
+         "started_at": "", "done_at": "2026-04-02T11:00:01",
+         "duration_s": 1.0, "retry_of": ""},
+    ]
+    jobs._JOBS_PATH.write_text(json.dumps(legacy), encoding="utf-8")
+
+    # First call triggers migration.
+    out = jobs.list_recent(10)
+    ids = {j.id for j in out}
+    assert {"abc123", "def456"} <= ids
+
+
+def test_migration_is_idempotent_across_calls():
+    legacy = [{"id": "x", "title": "t", "prompt": "p", "status": "done",
+               "source": "console", "steps": [], "step_count": 0,
+               "current_step": "", "result": "", "error": "",
+               "created_at": "2026-04-01", "started_at": "",
+               "done_at": "", "duration_s": 0.0, "retry_of": ""}]
+    jobs._JOBS_PATH.write_text(json.dumps(legacy), encoding="utf-8")
+
+    jobs.list_recent(10)
+    jobs.list_recent(10)
+    jobs.list_recent(10)
+
+    conn = schema.get_conn()
+    count = conn.execute("SELECT COUNT(*) FROM jobs WHERE id='x'").fetchone()[0]
+    assert count == 1
+
+
+def test_migration_marks_schema_meta_after_run():
+    jobs._JOBS_PATH.write_text("[]", encoding="utf-8")
+    jobs.list_recent(10)
+    conn = schema.get_conn()
+    row = conn.execute(
+        "SELECT value FROM schema_meta WHERE key='jobs_migrated_from_json'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "1"
+
+
+def test_migration_skips_when_no_legacy_file():
+    # Without a JSON file the migration mark is still set so we never
+    # re-scan on every call.
+    assert not jobs._JOBS_PATH.exists()
+    jobs.list_recent(10)
+    conn = schema.get_conn()
+    row = conn.execute(
+        "SELECT value FROM schema_meta WHERE key='jobs_migrated_from_json'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_migration_keeps_legacy_json_in_place():
+    """One-release fallback: the JSON file is left readable post-migration."""
+    legacy = [{"id": "x", "title": "t", "prompt": "p", "status": "done",
+               "source": "c", "steps": [], "step_count": 0,
+               "current_step": "", "result": "", "error": "",
+               "created_at": "2026-04-01", "started_at": "",
+               "done_at": "", "duration_s": 0.0, "retry_of": ""}]
+    jobs._JOBS_PATH.write_text(json.dumps(legacy), encoding="utf-8")
+    jobs.list_recent(10)
+    assert jobs._JOBS_PATH.exists()  # not deleted
+
+
+def test_migration_tolerates_corrupt_json():
+    jobs._JOBS_PATH.write_text("{ this is not json", encoding="utf-8")
+    # Should not raise — corrupt file is treated as empty.
+    out = jobs.list_recent(10)
+    assert out == []
+
+
+def test_new_jobs_after_migration_persist_to_sqlite():
+    legacy = [{"id": "old", "title": "t", "prompt": "p", "status": "done",
+               "source": "c", "steps": [], "step_count": 0,
+               "current_step": "", "result": "", "error": "",
+               "created_at": "2026-04-01", "started_at": "",
+               "done_at": "", "duration_s": 0.0, "retry_of": ""}]
+    jobs._JOBS_PATH.write_text(json.dumps(legacy), encoding="utf-8")
+    new_job = jobs.create("brand new", source="t")
+    fetched = jobs.get(new_job.id)
+    assert fetched is not None
+    assert fetched.prompt == "brand new"

--- a/tests/test_monitor_scheduler_events.py
+++ b/tests/test_monitor_scheduler_events.py
@@ -1,0 +1,146 @@
+"""F-3 tests for monitor/scheduler.py — report persistence + SSE event emission.
+
+Fetcher and summarizer are mocked so these tests don't touch the network
+or LLM providers.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import monitor.store as store
+import monitor.scheduler as scheduler
+from cc_daemon import events, schema
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(store, "STORE_PATH",
+                        tmp_path / "monitor_subscriptions.json")
+    schema.set_db_path(tmp_path / "sessions.db")
+    schema._local.conn = None
+    store._migration_done_in_process = False
+    events.reset_bus_for_tests()
+
+    # Replace fetch / summarize / deliver in scheduler's namespace so tests
+    # don't depend on network or LLM.  notifier.deliver returns
+    # {channel: error_or_empty} — empty string == success.
+    monkeypatch.setattr(scheduler, "fetch", lambda _topic: "raw stub")
+    monkeypatch.setattr(scheduler, "summarize",
+                        lambda raw, _config: f"SUMMARY: {raw}")
+    monkeypatch.setattr(scheduler, "deliver",
+                        lambda _report, channels, _config:
+                            {ch: "" for ch in channels})
+    monkeypatch.setattr(scheduler, "auto_channels", lambda _config: ["console"])
+
+    yield
+
+    schema._local.conn = None
+    schema.set_db_path(schema.get_default_db_path())
+
+
+# ── run_one persistence path ──────────────────────────────────────────────
+
+def test_run_one_persists_report_to_monitor_reports():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    out = scheduler.run_one("arxiv", config={})
+    assert "SUMMARY:" in out
+    reports = store.list_reports("arxiv")
+    assert len(reports) == 1
+    assert reports[0]["body"].startswith("SUMMARY:")
+    assert reports[0]["sent_to"] == ["console"]
+
+
+def test_run_one_records_failed_delivery_in_report():
+    store.add_subscription("arxiv", schedule="daily", channels=["telegram"])
+    # Force telegram delivery to fail
+    import monitor.scheduler as sched
+    def _failing_deliver(_report, channels, _config):
+        return {ch: "no token" for ch in channels}
+    sched.deliver = _failing_deliver
+    out = scheduler.run_one("arxiv", config={})
+    assert "[Delivery errors:" in out
+    reports = store.list_reports("arxiv")
+    assert len(reports) == 1
+    assert "Delivery errors" in reports[0]["body"]
+    # Successful sent_to is empty when all channels failed
+    assert reports[0]["sent_to"] == []
+
+
+def test_run_one_updates_last_run_on_subscription_row():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    assert store.get_subscription("arxiv")["last_run"] is None
+    scheduler.run_one("arxiv", config={})
+    assert store.get_subscription("arxiv")["last_run"] is not None
+
+
+# ── monitor_report SSE event ──────────────────────────────────────────────
+
+def test_run_one_publishes_monitor_report_event():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    bus = events.get_bus()
+    sub = bus.subscribe()
+    try:
+        scheduler.run_one("arxiv", config={})
+        evt = sub.get(timeout=2.0)
+        assert evt["type"] == "monitor_report"
+        assert evt["data"]["topic"] == "arxiv"
+        assert evt["data"]["sent_to"] == ["console"]
+        assert evt["data"]["errors"] == []
+        assert evt["data"]["body"].startswith("SUMMARY:")
+        # report_id ties the SSE event back to the row in monitor_reports
+        assert evt["data"]["report_id"]
+    finally:
+        bus.unsubscribe(sub)
+
+
+def test_event_report_id_matches_persisted_row():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    bus = events.get_bus()
+    sub = bus.subscribe()
+    try:
+        scheduler.run_one("arxiv", config={})
+        evt = sub.get(timeout=2.0)
+        report_id = evt["data"]["report_id"]
+        rows = store.list_reports("arxiv")
+        assert any(r["id"] == report_id for r in rows)
+    finally:
+        bus.unsubscribe(sub)
+
+
+def test_event_carries_error_list_on_partial_failure():
+    store.add_subscription("arxiv", schedule="daily",
+                            channels=["telegram", "console"])
+    import monitor.scheduler as sched
+    sched.deliver = lambda _r, channels, _c: {
+        "telegram": "no token", "console": ""}
+    bus = events.get_bus()
+    sub = bus.subscribe()
+    try:
+        scheduler.run_one("arxiv", config={})
+        evt = sub.get(timeout=2.0)
+        assert evt["data"]["sent_to"] == ["console"]
+        assert any("telegram" in e for e in evt["data"]["errors"])
+    finally:
+        bus.unsubscribe(sub)
+
+
+# ── Survives daemon restart (key F-3 win) ────────────────────────────────
+
+def test_reports_survive_simulated_daemon_restart():
+    """Persist a few reports, drop the events singleton (mimic restart),
+    and verify list_reports still returns them — the SQLite source of
+    truth means cross-restart history is intact."""
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    scheduler.run_one("arxiv", config={})
+    scheduler.run_one("arxiv", config={})
+    events.reset_bus_for_tests()  # bus fresh, but daemon_events also cleared
+    # daemon_events is event log, not report log — restart it to mimic
+    # a fresh daemon process picking up persisted reports.
+    reports = store.list_reports("arxiv")
+    assert len(reports) == 2

--- a/tests/test_monitor_store_sqlite.py
+++ b/tests/test_monitor_store_sqlite.py
@@ -1,0 +1,206 @@
+"""F-3 tests for monitor/store.py — SQLite backing + JSON migration."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import monitor.store as store
+from cc_daemon import schema
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch):
+    """Each test gets a private sessions.db AND a tmp STORE_PATH so the
+    legacy migration can't touch the developer's real file."""
+    monkeypatch.setattr(store, "STORE_PATH", tmp_path / "monitor_subscriptions.json")
+    schema.set_db_path(tmp_path / "sessions.db")
+    schema._local.conn = None
+    store._migration_done_in_process = False
+    yield
+    schema._local.conn = None
+    schema.set_db_path(schema.get_default_db_path())
+
+
+# ── CRUD ────────────────────────────────────────────────────────────────────
+
+def test_add_then_list_returns_subscription():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    subs = store.list_subscriptions()
+    assert len(subs) == 1
+    assert subs[0]["topic"] == "arxiv"
+    assert subs[0]["schedule"] == "daily"
+    assert subs[0]["channels"] == ["console"]
+
+
+def test_add_is_upsert():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    store.add_subscription("arxiv", schedule="6h", channels=["telegram"])
+    subs = store.list_subscriptions()
+    assert len(subs) == 1
+    assert subs[0]["schedule"] == "6h"
+    assert subs[0]["channels"] == ["telegram"]
+
+
+def test_get_subscription_returns_none_when_absent():
+    assert store.get_subscription("nope") is None
+
+
+def test_get_subscription_returns_match():
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    sub = store.get_subscription("arxiv")
+    assert sub is not None
+    assert sub["topic"] == "arxiv"
+
+
+def test_remove_subscription_returns_true_when_removed():
+    store.add_subscription("arxiv", schedule="daily")
+    assert store.remove_subscription("arxiv") is True
+    assert store.list_subscriptions() == []
+
+
+def test_remove_subscription_returns_false_when_absent():
+    assert store.remove_subscription("never-was") is False
+
+
+def test_update_last_run_records_timestamp_and_preview():
+    store.add_subscription("arxiv", schedule="daily")
+    store.update_last_run("arxiv", "Today's findings: …" + "x" * 1000)
+    sub = store.get_subscription("arxiv")
+    assert sub["last_run"] is not None
+    # last_report preview is ≤500 chars per legacy behaviour
+    assert len(sub["last_report"]) <= 500
+
+
+def test_subscription_persists_across_connections():
+    """Drop and re-create the thread-local connection to mimic a fresh
+    process reading the same DB."""
+    store.add_subscription("arxiv", schedule="daily", channels=["console"])
+    schema._local.conn = None  # drop conn → next call re-opens
+    subs = store.list_subscriptions()
+    assert any(s["topic"] == "arxiv" for s in subs)
+
+
+# ── JSON → SQLite migration ──────────────────────────────────────────────
+
+def _legacy_payload(subs: list[dict]) -> str:
+    return json.dumps({"subscriptions": subs}, ensure_ascii=False)
+
+
+def test_migration_imports_legacy_subscriptions(tmp_path):
+    legacy = [
+        {"id": "abc12345", "topic": "arxiv", "schedule": "daily",
+         "channels": ["console"], "created_at": "2026-04-01T10:00:00",
+         "last_run": "2026-04-02T10:00:00", "next_run": None,
+         "last_report": "Yesterday's report …"},
+        {"id": "def67890", "topic": "news", "schedule": "6h",
+         "channels": ["telegram"], "created_at": "2026-04-01T10:00:00",
+         "last_run": None, "next_run": None, "last_report": None},
+    ]
+    store.STORE_PATH.write_text(_legacy_payload(legacy), encoding="utf-8")
+    subs = store.list_subscriptions()
+    topics = {s["topic"] for s in subs}
+    assert {"arxiv", "news"} <= topics
+
+
+def test_migration_carries_last_run_and_channels():
+    legacy = [{"id": "x", "topic": "arxiv", "schedule": "daily",
+               "channels": ["telegram", "console"],
+               "created_at": "2026-04-01T10:00:00",
+               "last_run": "2026-04-02T10:00:00", "next_run": None,
+               "last_report": "old digest"}]
+    store.STORE_PATH.write_text(_legacy_payload(legacy), encoding="utf-8")
+    sub = store.get_subscription("arxiv")
+    assert sub["last_run"] == "2026-04-02T10:00:00"
+    assert set(sub["channels"]) == {"telegram", "console"}
+
+
+def test_migration_seeds_last_report_into_monitor_reports():
+    """A subscription with last_report should produce one row in
+    monitor_reports so the post-upgrade /monitor history view isn't
+    empty."""
+    legacy = [{"id": "x", "topic": "arxiv", "schedule": "daily",
+               "channels": ["console"], "created_at": "",
+               "last_run": "2026-04-02T10:00:00", "next_run": None,
+               "last_report": "Old digest body"}]
+    store.STORE_PATH.write_text(_legacy_payload(legacy), encoding="utf-8")
+    store.list_subscriptions()  # triggers migration
+    reports = store.list_reports("arxiv")
+    assert len(reports) == 1
+    assert reports[0]["body"] == "Old digest body"
+
+
+def test_migration_is_idempotent():
+    legacy = [{"id": "x", "topic": "arxiv", "schedule": "daily",
+               "channels": [], "created_at": "", "last_run": None,
+               "next_run": None, "last_report": None}]
+    store.STORE_PATH.write_text(_legacy_payload(legacy), encoding="utf-8")
+    store.list_subscriptions()
+    store.list_subscriptions()
+    store.list_subscriptions()
+    subs = store.list_subscriptions()
+    assert sum(1 for s in subs if s["topic"] == "arxiv") == 1
+
+
+def test_migration_marker_is_recorded():
+    store.STORE_PATH.write_text(_legacy_payload([]), encoding="utf-8")
+    store.list_subscriptions()
+    row = schema.get_conn().execute(
+        "SELECT value FROM schema_meta WHERE key='monitor_migrated_from_json'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "1"
+
+
+def test_migration_keeps_legacy_file_in_place():
+    legacy = [{"id": "x", "topic": "arxiv", "schedule": "daily",
+               "channels": [], "created_at": "", "last_run": None,
+               "next_run": None, "last_report": None}]
+    store.STORE_PATH.write_text(_legacy_payload(legacy), encoding="utf-8")
+    store.list_subscriptions()
+    assert store.STORE_PATH.exists()  # one-release fallback
+
+
+def test_migration_tolerates_corrupt_json():
+    store.STORE_PATH.write_text("{ this is not json", encoding="utf-8")
+    # Should not raise.
+    assert store.list_subscriptions() == []
+
+
+# ── Reports ─────────────────────────────────────────────────────────────────
+
+def test_save_report_returns_id_and_persists():
+    store.add_subscription("arxiv", schedule="daily")
+    rid = store.save_report("arxiv", "Today's digest", sent_to=["console"])
+    assert rid
+    reports = store.list_reports("arxiv")
+    assert len(reports) == 1
+    assert reports[0]["id"] == rid
+    assert reports[0]["body"] == "Today's digest"
+    assert reports[0]["sent_to"] == ["console"]
+
+
+def test_list_reports_filters_by_topic():
+    store.add_subscription("arxiv", schedule="daily")
+    store.add_subscription("news", schedule="6h")
+    store.save_report("arxiv", "A", sent_to=[])
+    store.save_report("news", "N", sent_to=[])
+    store.save_report("arxiv", "B", sent_to=[])
+    arxiv_reports = store.list_reports("arxiv")
+    assert {r["body"] for r in arxiv_reports} == {"A", "B"}
+
+
+def test_list_reports_orders_newest_first():
+    store.add_subscription("arxiv", schedule="daily")
+    store.save_report("arxiv", "first", sent_to=[])
+    store.save_report("arxiv", "second", sent_to=[])
+    store.save_report("arxiv", "third", sent_to=[])
+    reports = store.list_reports("arxiv")
+    # Most recent first
+    assert reports[0]["body"] == "third"
+    assert reports[-1]["body"] == "first"


### PR DESCRIPTION
Combined PR for **F-2 (persistence)** and **F-3 (monitor in daemon)** from the foundation roadmap (`docs/RFC/0002-daemon-foundation-roadmap.md`).  Bundled because F-2 alone is plumbing — F-3 is the first concrete user-visible win that makes the daemon worth running.

Two commits on top of `upstream/main` (post-#80 polish, daemon-spike re-merged via #81):

- `428055a feat(daemon): F-2 persistence — SQLite schema, events store, jobs migration`
- `d912936 feat(monitor): F-3 monitor scheduler runs in daemon`

Reviewable per-commit; the F-3 commit only touches files F-2 didn't.

## Headline user-visible win (F-3)

```
[REPL]
> /monitor subscribe arxiv --schedule daily --console
> /exit

[daemon (cheetahclaws serve) keeps running]
... 24 h later ...
   scheduler.run_one("arxiv")
   → fetch + summarize + deliver to console
   → save_report(...)        → row in monitor_reports
   → events.publish(...)     → `monitor_report` SSE frame
   → SSE clients (Web UI, future bridges) see the digest live

[user reopens REPL the next morning]
> /monitor history arxiv
   → list_reports("arxiv") returns the daemon-fired digest
```

Subscriptions persist, the schedule keeps firing, reports + events land in SQLite, history is intact across REPL sessions and daemon restarts.

## What's in F-2

Foundation for F-3..F-9 — gives the daemon a canonical SQLite home for everything that should survive a daemon restart.

- **`cc_daemon/schema.py`** — eight additive tables in the existing `~/.cheetahclaws/sessions.db`: `schema_meta`, `daemon_events`, `agent_runs`, `agent_iterations`, `jobs`, `monitor_subscriptions`, `monitor_reports`, `bridges`.  `session_store`'s `sessions` / `sessions_fts` tables are not touched.  `init_schema(db_path)` is idempotent and internally locked; `get_conn()` is thread-local and mirrors `session_store`'s WAL + busy_timeout pattern.
- **`cc_daemon/events.py`** — `EventBus` rewritten on top of `daemon_events`.  `publish()` INSERTs (id is `AUTOINCREMENT`, monotonic across daemon restarts and across retention pruning) and fans out to in-process subscribers.  `replay_since(N)` reads from SQLite and yields a synthetic `gap` event when retention has evicted what the client wanted.  Default retention 24 h / 100 K rows; opportunistic prune every 100 publishes.  Public API (`EventBus`, `format_sse`, `heartbeat_frame`, `get_bus`, `reset_bus_for_tests`, `RING_CAP`, `HEARTBEAT_INTERVAL_S`) preserved exactly; spike's contract suite passes unchanged with two ring-buffer tests rewritten in place to test the new retention semantics (same contract, different mechanism).
- **`jobs.py`** — `_persist` / `_row_to_job` hit SQLite via `cc_daemon.schema.get_conn()`; `_ensure_migrated()` imports legacy `~/.cheetahclaws/jobs.json` once (tracked by `schema_meta.jobs_migrated_from_json`).  JSON file left readable for one release as fallback.  Public API unchanged.
- **`cc_daemon/cli.py:cmd_serve`** — calls `schema.init_schema()` right after `bootstrap()` so the tables exist before the listener accepts traffic.

**Behavior change worth flagging**: ISO timestamps in `daemon_events` now have microsecond precision (`%Y-%m-%dT%H:%M:%S.%fZ`).  Sub-second matters for retention by age — without it, two events in the same second would prune as a single bucket.  String comparison still sorts correctly.

## What's in F-3

First service migrated into the daemon.  Subscription store moves from JSON to SQLite; reports persist + emit SSE events; scheduler runs daemon-side; REPL skips its local scheduler when a daemon is detected.

- **`monitor/store.py`** — SQLite-backed.  Same public API as the legacy JSON store.  One-shot legacy import tracked by `schema_meta.monitor_migrated_from_json`; JSON file kept readable for one release.  Legacy `last_report` field migrated as a single row in `monitor_reports` so `/monitor history` works post-upgrade.  New helpers: `save_report` / `list_reports`.
- **`monitor/scheduler.py`** — `run_one()` persists the full report body via `save_report` and publishes a `monitor_report` event on the SSE bus with `{topic, report_id, body, sent_to, errors}`.  `report_id` ties the event to the row in `monitor_reports`.  Loop's idle wait switched from `time.sleep(30)` × 60 to `Event.wait(60)` so daemon shutdown is no longer stalled up to 30 s waiting for the scheduler thread to wake.
- **`cc_daemon/monitor_methods.py`** — RPC methods `monitor.subscribe`, `monitor.unsubscribe`, `monitor.list`, `monitor.run` for external clients (Web UI / future bridges).  Registered from `DaemonState.__init__` next to `system_methods`.
- **`cc_daemon/cli.py:cmd_serve`** — starts `monitor.scheduler.start(config)` after schema init.  Existing shutdown watcher calls `monitor.scheduler.stop()` before triggering `server.shutdown()`.
- **`commands/monitor_cmd.py`** — `/monitor start` and `/monitor stop` call `cc_daemon.discovery.locate()`; if a live daemon is found, print "scheduler is owned by the running daemon" and no-op.  Avoids the race of two schedulers fighting over `last_run_at`.  `/monitor subscribe` / `unsubscribe` / `list` keep working in REPL because they hit SQLite directly; daemon picks up new state on its next 60 s poll.

## What's NOT in this PR (intentional)

- **Telegram / Slack / WeChat delivery from daemon** — bridges still in REPL.  A subscription with `--telegram` will land its report in `monitor_reports` and fire the SSE event when the daemon scheduler runs, but won't actually push to the phone unless REPL is also running with the bridge connected.  Full "Telegram digest survives REPL exit" is F-6's job.
- **Per-method permission gating on monitor RPCs** — open to any authenticated caller in F-3.  Permission-gated RPC arrives with the `agent.run` integration in later F-* PRs.
- **`agent.run` integration / `session.send`** — F-3+ scope; not here.
- **`agent_runner` subprocess-per-agent, `proactive`, bridges, cost guardrails** — F-4..F-9.

## Tests

| Suite | Cases | Notes |
|---|---|---|
| `test_cc_daemon_schema.py` | 12 | idempotent init, all tables present, `session_store` not disturbed |
| `test_cc_daemon_events_sqlite.py` | 15 | persistence, retention by row count + age, gap, reset, cross-instance replay |
| `test_jobs_sqlite.py` | 14 | CRUD + JSON migration (idempotency, corrupt-file tolerance, legacy file kept) |
| `test_daemon_spike.py` | 13 | spike contract suite — two ring-buffer tests rewritten in place to test retention |
| `test_monitor_store_sqlite.py` | 18 | CRUD + JSON migration + `last_report` seeded into `monitor_reports` |
| `test_monitor_scheduler_events.py` | 7 | `run_one` persists report, publishes `monitor_report` event, error flow into payload, restart survival |
| `test_cc_daemon_monitor_methods.py` | 12 | RPC subscribe/unsubscribe/list/run + coexistence with system_methods |
| `e2e_daemon_skeleton.py` (additions) | 3 | sessions.db init on serve; cross-process event replay across daemon restart; **subscribe via RPC survives daemon restart** |

`pytest tests/ -q --ignore=tests/test_input_completer.py` → **763 passed, 3 skipped, 0 failed** (3 skips are POSIX-only tests on the Windows dev machine; the pre-existing GBK-encoding failure in `test_input_completer.py` is unrelated and fails on `upstream/main` too).

## Roadmap status

`docs/RFC/0002-daemon-foundation-roadmap.md` — F-2 and F-3 marked OPEN; per-PR detail sections rewritten to match what landed.  F-4..F-9 unchanged.

Refs #68, #74, #80
