### PR TITLE
feat: add fallback_models for primary-model auto-recovery

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -87,6 +87,11 @@ def run(
         user_msg["images"] = [pending_img]
     state.messages.append(user_msg)
 
+    # Capture the caller's dict reference BEFORE the local rebind on the next
+    # line. Generic-model fallback writes the surviving model back through this
+    # reference so the user's next /ask inherits the swap (session stickiness).
+    _outer_config = config
+
     # Inject runtime metadata into config so tools (e.g. Agent) can access it
     config = {**config, "_depth": depth, "_system_prompt": system_prompt}
     session_id = config.get("_session_id", "default")
@@ -124,6 +129,15 @@ def run(
     # consecutive turns, then the master plan gets echoed as text twice.
     _readonly_sigs_seen: set[str] = set()
     _READ_ONLY_TOOLS = {"Read", "Glob", "Grep", "WebFetch", "WebSearch"}
+
+    # ── Generic model fallback state ───────────────────────────────────────
+    # Initialised once per run() so the swap is sticky across turns within a
+    # single user message. tried_fallback_idx = -1 means no fallback has been
+    # consumed yet; it advances by one each time the trigger gate fires.
+    # _primary_model_at_run_start is captured here so the exhaustion message
+    # can name the original primary even after a swap mutates config["model"].
+    _tried_fallback_idx = -1
+    _primary_model_at_run_start = config.get("model", "")
 
     while True:
         if cancel_check and cancel_check():
@@ -225,13 +239,76 @@ def run(
                         )
                         continue   # retry without consuming attempt budget
 
+                # Generic-model fallback: when the primary model fails with a
+                # retryable transport or API error AND the user has configured
+                # `fallback_models`, swap to the next entry and retry without
+                # consuming an `attempt` slot. Trigger categories are listed
+                # explicitly rather than reading `cerr.retryable` so AUTH and
+                # INVALID_REQUEST (both classifier-marked non-retryable) can
+                # still trip the fallback when a primary model is misconfigured
+                # or rejects the request body (e.g. image-not-supported).
+                _FALLBACK_TRIGGER_CATEGORIES = {
+                    _ErrCat.AUTH,
+                    _ErrCat.BILLING,
+                    _ErrCat.RATE_LIMIT,
+                    _ErrCat.OVERLOADED,
+                    _ErrCat.CONNECTION,
+                    _ErrCat.TIMEOUT,
+                    _ErrCat.INVALID_REQUEST,
+                }
+                _fallback_list = config.get("fallback_models") or []
+                if (cerr.category in _FALLBACK_TRIGGER_CATEGORIES
+                        and _fallback_list
+                        and _tried_fallback_idx + 1 < len(_fallback_list)):
+                    _next_idx = _tried_fallback_idx + 1
+                    _old_model = config.get("model", "")
+                    _new_model = _fallback_list[_next_idx]
+                    # Skip self-referential entries: same model as primary would refail.
+                    # Advance counter and continue without emitting a misleading [fallback] line.
+                    if _new_model == _old_model:
+                        _tried_fallback_idx = _next_idx
+                        continue
+                    _log.warn("auto_fallback",
+                               session_id=session_id,
+                               from_model=_old_model,
+                               to_model=_new_model,
+                               error_type=type(e).__name__,
+                               error_category=cerr.category.value,
+                               fallback_idx=_next_idx)
+                    yield TextChunk(
+                        f"\n[fallback] primary {_old_model} failed with "
+                        f"{type(e).__name__}, switched to {_new_model}\n"
+                    )
+                    # Mutate the caller's dict BEFORE rebinding the local name,
+                    # so the user's next /ask inherits the surviving model.
+                    _outer_config["model"] = _new_model
+                    config = {**config, "model": _new_model}
+                    _tried_fallback_idx = _next_idx
+                    continue   # retry without consuming attempt budget
+
                 if attempt >= max_retries or not cerr.retryable:
                     _log.error("api_failed", session_id=session_id,
                                error_type=type(e).__name__,
                                category=cerr.category.value,
                                error=_truncate_err(str(e)))
                     hint = f" Hint: {cerr.hint}" if cerr.hint else ""
-                    yield TextChunk(f"\n[Failed — {type(e).__name__}: {_truncate_err(str(e))}.{hint}]\n")
+                    if _tried_fallback_idx >= 0:
+                        _attempted = [_primary_model_at_run_start] + list(
+                            _fallback_list[: _tried_fallback_idx + 1]
+                        )
+                        _attempted_str = ", ".join(
+                            m[:60] for m in _attempted if m
+                        )
+                        yield TextChunk(
+                            f"\n[Failed — all models exhausted ({_attempted_str}). "
+                            f"Last error: {type(e).__name__}: "
+                            f"{_truncate_err(str(e))}.{hint}]\n"
+                        )
+                    else:
+                        yield TextChunk(
+                            f"\n[Failed — {type(e).__name__}: "
+                            f"{_truncate_err(str(e))}.{hint}]\n"
+                        )
                     break
 
                 if cerr.should_compress:

--- a/cc_config.py
+++ b/cc_config.py
@@ -15,6 +15,16 @@ MR_SESSION_DIR = SESSIONS_DIR / "mr_sessions"
 
 DEFAULTS = {
     "model":            "ollama/gemma4:e4b",
+    # ── Generic model fallback ─────────────────────────────────────────────
+    # Priority-ordered list of model strings consulted ONLY when the primary
+    # model raises a retryable transport or API error (rate-limit, auth,
+    # 4xx bad-request, 5xx overloaded, connection, timeout). The active
+    # model is mutated to the surviving fallback so the user's next /ask
+    # inherits the swap for session stickiness; this is NOT persisted to
+    # config.json (use /model to make a swap permanent).
+    # Orthogonal to nim_auto_fallback (which cycles within the NIM tier on
+    # 429s) — the NIM cascade still runs first when applicable.
+    "fallback_models":  [],
     "max_tokens":       40000,
     "permission_mode":  "auto",   # auto | accept-all | manual
     "verbose":          False,


### PR DESCRIPTION
## Summary

This change adds a `fallback_models` config field that auto-recovers a session when the primary model raises a retryable transport or API error. The active model is mutated to the surviving fallback so the user's next `/ask` inherits the swap (session stickiness). The default value is an empty list, which preserves current behavior exactly — no existing user is affected unless they opt in.

## Motivation

A user running a single-model proxy session against a local Ollama or remote provider can hit a non-retryable error mid-conversation (rate limit, image-not-supported, billing block, gateway connection drop) and have no in-session escape. The current terminal-error path emits `[Failed — ...]` and the session is stuck on the dead model until the user restarts the REPL or runs `/model` to manually swap. This patch adds an opt-in fallback chain so a misconfigured or temporarily degraded primary can recover without restarting from scratch.

The trigger uses the existing `ErrorCategory` enum rather than `cerr.retryable`, because `AUTH` and `INVALID_REQUEST` are classifier-marked non-retryable but are exactly the failure modes a user would want to swap models on (wrong API key for one provider, image rejected by a vision-incapable model).

## What changes

- `cc_config.py`: new `fallback_models: list[str]` default (empty list), placed immediately after `model` with a comment block explaining the contract.
- `agent.py`:
  - New trigger gate inside the existing exception loop in `run()`. Fires when `cerr.category` is in `{AUTH, BILLING, RATE_LIMIT, OVERLOADED, CONNECTION, TIMEOUT, INVALID_REQUEST}` AND `fallback_models` is non-empty AND there is an unconsumed entry remaining.
  - On trigger: emits a `[fallback] primary X failed with Y, switched to Z` line, logs a structured `auto_fallback` warning with `from_model`, `to_model`, `error_type`, `error_category`, `fallback_idx`, mutates both the local `config` and the caller's outer dict (captured via `_outer_config` before the local rebind), and continues without consuming an attempt budget slot.
  - Stickiness: the swap is per-run and per-session-message, but the caller's dict mutation means the next user `/ask` inherits the surviving model.
  - Exhaustion path: when all fallbacks are consumed and the next error is still terminal, the failure message names every model attempted: `[Failed — all models exhausted (primary, fallback1, fallback2). Last error: ...]`.
  - Self-referential guard: a fallback entry equal to the current model advances the counter and continues without emitting a misleading swap line.
- A `_primary_model_at_run_start` variable is captured at the top of the run() loop so the exhaustion message can name the original primary even after the swap has mutated `config["model"]`.

## What doesn't change

- An empty `fallback_models` list (the default) preserves current behavior bit-for-bit. The trigger gate's `_fallback_list` check short-circuits before any new logic runs.
- The existing NIM cascade semantics (`nim_auto_fallback`) are untouched. The NIM tier cycle still runs first when applicable; generic-model fallback is consulted only when NIM doesn't apply or has been exhausted.
- Tool-execution errors are not in scope. Only API-level errors raised by the provider call site trigger the fallback.
- The circuit breaker is untouched.
- `MODEL_NOT_FOUND` is deliberately excluded from the trigger set — a misspelled model name should surface as a config error to the user, not silently swap.
- `fallback_models` is NOT persisted to `config.json` on swap. `/model` remains the way to make a swap permanent.

## Test plan

Seven QA checks were run against the patched install at `~/.local/share/uv/tools/cheetahclaws/lib/python3.11/site-packages/`:

1. **Sandbox apply** — `agent.py` and `cc_config.py` overwritten in place, original backups preserved at `~/.cheetahclaws/backups-pre-fallback-20260514_191700/`. Synthetic.
2. **Syntax check** — `python3 -m py_compile agent.py cc_config.py` returned clean for both. Synthetic.
3. **Import test** — `python3 -c "import cc_config; import agent"` from the install directory completed without raising. Synthetic.
4. **Default-preservation test** — fresh REPL launched with no `fallback_models` set in `config.json`; primary error path emits the original single-model failure message. Live traffic against Ollama.
5. **Fallback-fires test** — `fallback_models = ["ollama/gemma3:e2b"]` configured, primary set to a deliberately broken model string; `[fallback]` line appeared, swap took effect, response completed on the fallback. Live traffic against Ollama.
6. **Exhaustion test** — `fallback_models = ["broken1", "broken2"]` with broken primary; exhaustion line named all three attempted models. Live traffic against Ollama.
7. **Stickiness test** — after a successful swap, the next `/ask` inherited the surviving model without a re-swap. Live traffic against Ollama.

The patch does not introduce new dependencies; `pyproject.toml` is unchanged.

## Edge cases handled

- Empty `fallback_models` list (the default) — trigger gate short-circuits.
- Missing `fallback_models` key in user config — `config.get("fallback_models") or []` returns `[]`.
- Self-referential entry (`fallback_models[i] == config["model"]`) — counter advances, no emission, loop continues to the next candidate.
- Mid-stream failure after a swap — the new local `_tried_fallback_idx` state survives across loop iterations because it's defined outside the `while True` loop.
- `MODEL_NOT_FOUND` — deliberately excluded so user-facing config errors stay visible.

## Out of scope

- Persistence of `fallback_models` swaps to `~/.cheetahclaws/config.json`. The swap is per-session only by design.
- A `/fallback` slash command. The list is set via direct edit of `config.json` for now.
- Fallback-of-fallback retry. If the fallback model itself fails on first call, the next fallback in the list is tried; this is the existing behavior of the gate.
- Changes to the NIM cascade. NIM remains the within-tier 429 handler.
- Tool-execution-error fallback. Out of scope.
