### PR TITLE
Fix long-response fallback in Rich streaming

### DIFF
--- a/tests/test_render_streaming.py
+++ b/tests/test_render_streaming.py
@@ -1,0 +1,140 @@
+import pytest
+import ui.render as render
+
+
+class _FakeLive:
+    def __init__(self, *args, **kwargs):
+        self.started = False
+        self.stopped = False
+        self.updates = []
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def update(self, value, refresh=False):
+        self.updates.append((value, refresh))
+
+
+class _FakeConsole:
+    height = 100
+    options = object()
+
+    def __init__(self):
+        self.printed = []
+
+    def print(self, value):
+        self.printed.append(value)
+
+
+@pytest.fixture
+def patched_render(monkeypatch):
+    previous_state = (
+        list(render._accumulated_text),
+        render._current_live,
+        render._plain_streaming_response,
+    )
+    fake_console = _FakeConsole()
+    live_instances = []
+
+    def fake_live(*args, **kwargs):
+        live = _FakeLive(*args, **kwargs)
+        live_instances.append(live)
+        return live
+
+    monkeypatch.setattr(render, "_RICH", True)
+    monkeypatch.setattr(render, "_RICH_LIVE", True)
+    monkeypatch.setattr(render, "console", fake_console)
+    monkeypatch.setattr(render, "Live", fake_live)
+    monkeypatch.setattr(render, "_make_renderable", lambda text: text)
+    monkeypatch.setattr(render, "_live_line_limit", lambda: 80)
+
+    render._accumulated_text.clear()
+    render._current_live = None
+    render._plain_streaming_response = False
+
+    yield fake_console, live_instances
+
+    render._accumulated_text[:] = previous_state[0]
+    render._current_live = previous_state[1]
+    render._plain_streaming_response = previous_state[2]
+
+
+def test_stream_text_uses_one_live_renderer_with_accumulated_chunks(patched_render, monkeypatch, capsys):
+    fake_console, live_instances = patched_render
+    monkeypatch.setattr(render, "_rendered_line_count", lambda _: 10)
+
+    render.stream_text("first")
+    render.stream_text(" second")
+
+    assert capsys.readouterr().out == ""
+    assert fake_console.printed == []
+    assert len(live_instances) == 1
+    live = live_instances[0]
+    assert live.started is True
+    assert live.stopped is False
+    assert live.updates == [("first", True), ("first second", True)]
+    assert render._accumulated_text == ["first", " second"]
+    assert render._plain_streaming_response is False
+
+    render.flush_response()
+
+    assert live.stopped is True
+    assert render._accumulated_text == []
+    assert render._current_live is None
+    assert render._plain_streaming_response is False
+
+
+def test_stream_text_falls_back_to_plain_when_first_chunk_exceeds_live_limit(
+    patched_render, monkeypatch, capsys
+):
+    fake_console, live_instances = patched_render
+    monkeypatch.setattr(render, "_rendered_line_count", lambda _: 81)
+
+    render.stream_text("first")
+    render.stream_text(" second")
+
+    assert live_instances == []
+    assert fake_console.printed == ["first"]
+    assert capsys.readouterr().out == " second"
+    assert render._accumulated_text == []
+    assert render._current_live is None
+    assert render._plain_streaming_response is True
+
+    render.flush_response()
+
+    assert capsys.readouterr().out == "\n"
+    assert render._plain_streaming_response is False
+
+    monkeypatch.setattr(render, "_rendered_line_count", lambda _: 10)
+    render.stream_text("short")
+
+    assert len(live_instances) == 1
+    assert live_instances[0].updates == [("short", True)]
+    assert render._plain_streaming_response is False
+
+
+def test_stream_text_stops_active_live_before_falling_back_to_plain(patched_render, monkeypatch):
+    fake_console, live_instances = patched_render
+    rendered_counts = iter([10, 81])
+
+    monkeypatch.setattr(
+        render,
+        "_rendered_line_count",
+        lambda _renderable: next(rendered_counts),
+    )
+
+    render.stream_text("first")
+    render.stream_text(" second")
+
+    assert len(live_instances) == 1
+    live = live_instances[0]
+    assert live.started is True
+    assert live.stopped is True
+    assert live.updates == [("first", True), ("", True)]
+    assert fake_console.printed == ["first second"]
+    assert render._accumulated_text == []
+    assert render._current_live is None
+    assert render._plain_streaming_response is True

--- a/ui/render.py
+++ b/ui/render.py
@@ -152,6 +152,7 @@ def _has_diff(text: str) -> bool:
 _accumulated_text: list[str] = []   # buffer text during streaming
 _current_live = None                # active Rich Live instance (one at a time)
 _RICH_LIVE = True                   # set False (via config rich_live=false) to disable
+_plain_streaming_response = False   # current response has fallen back from Live
 
 def set_rich_live(enabled: bool) -> None:
     """Called from repl.py to apply the rich_live config setting."""
@@ -175,36 +176,71 @@ def _start_live() -> None:
 _LIVE_LINE_LIMIT = 80  # auto-switch to plain streaming beyond this many lines
 
 
+def _live_line_limit() -> int:
+    """Return a conservative Live height limit for the current terminal."""
+    height = getattr(console, "height", 0) or 0
+    if height > 0:
+        return min(_LIVE_LINE_LIMIT, max(12, height - 4))
+    return _LIVE_LINE_LIMIT
+
+
+def _rendered_line_count(renderable) -> int:
+    """Estimate actual terminal lines after Rich wrapping / Markdown rendering."""
+    if not (_RICH and console is not None):
+        return 0
+    try:
+        lines = console.render_lines(renderable, console.options, pad=False)
+        return len(lines)
+    except Exception:
+        return 0
+
+
+def _stop_live(clear: bool = False) -> None:
+    """Stop the active Live renderer, optionally clearing its last frame first."""
+    global _current_live
+    if _current_live is None:
+        return
+    if clear:
+        try:
+            _current_live.update("", refresh=True)
+        except Exception:
+            pass
+    _current_live.stop()
+    _current_live = None
+
+
 def stream_text(chunk: str) -> None:
     """Buffer chunk; update Live in-place when Rich available, else print directly.
 
-    Safety: if accumulated text exceeds _LIVE_LINE_LIMIT lines, auto-switch
-    from Rich Live to plain streaming to prevent terminal re-render duplication
-    on terminals that can't handle large Live areas (macOS Terminal, etc.).
+    Safety: if accumulated text renders to too many terminal lines, auto-switch
+    from Rich Live to plain streaming for the rest of this response. Live
+    redraws the full accumulated output on every chunk; large wrapped output is
+    where terminal emulators commonly leave stale frames behind.
     """
-    global _current_live
+    global _current_live, _plain_streaming_response
+
+    if _plain_streaming_response:
+        print(chunk, end="", flush=True)
+        return
+
     _accumulated_text.append(chunk)
 
     if _RICH and _RICH_LIVE:
         full = "".join(_accumulated_text)
-        line_count = full.count("\n")
+        renderable = _make_renderable(full)
+        line_count = max(full.count("\n") + 1, _rendered_line_count(renderable))
 
         # Safety: too many lines → kill Live and fall back to plain streaming
-        if _current_live is not None and line_count > _LIVE_LINE_LIMIT:
-            _current_live.stop()
-            _current_live = None
-            # Print the full text once (Live already displayed partial content,
-            # but stopping Live clears it — so we re-print cleanly)
-            console.print(_make_renderable(full))
+        if line_count > _live_line_limit():
+            _stop_live(clear=True)
+            console.print(renderable)
+            _accumulated_text.clear()
+            _plain_streaming_response = True
             return
 
-        if line_count <= _LIVE_LINE_LIMIT:
-            if _current_live is None:
-                _start_live()
-            _current_live.update(_make_renderable(full), refresh=True)
-        else:
-            # Already past limit, no Live — just append new chunk
-            print(chunk, end="", flush=True)
+        if _current_live is None:
+            _start_live()
+        _current_live.update(renderable, refresh=True)
     else:
         print(chunk, end="", flush=True)
 
@@ -216,16 +252,16 @@ def stream_thinking(chunk: str, verbose: bool):
 
 def flush_response() -> None:
     """Commit buffered text to screen: stop Live (freezes rendered Markdown in place)."""
-    global _current_live
+    global _current_live, _plain_streaming_response
     full = "".join(_accumulated_text)
     _accumulated_text.clear()
     if _current_live is not None:
-        _current_live.stop()
-        _current_live = None
+        _stop_live()
     elif _RICH and _RICH_LIVE and full.strip():
         console.print(_make_renderable(full))
     else:
         print()  # ensure newline after plain-text stream
+    _plain_streaming_response = False
 
 
 # ── Spinner ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix Rich Live streaming fallback for long responses.

## Problem

Large streamed responses can exceed the practical redraw area for Rich Live. In some terminals, this may leave stale or duplicated output while the response is still streaming. The previous fallback logic also did not fully isolate fallback mode to the current response.

## Changes

- Added per-response plain streaming fallback state.
- Estimate rendered line count with Rich instead of relying only on newline counts.
- Make the Live line limit aware of terminal height.
- Stop and clear the active Live frame before falling back to plain output.
- Clear the accumulated buffer after fallback to avoid duplicate output.
- Reset fallback state in `flush_response()` so the next response can use Live again.
- Added focused tests for normal Live streaming, first-chunk fallback, and active-Live fallback.

## Test Plan

```bash
uv run pytest -q tests/test_render_streaming.py
```
