### PR TITLE
Add context_window override so the prompt %/compaction follow it live

### DIFF
--- a/cc_config.py
+++ b/cc_config.py
@@ -15,7 +15,13 @@ MR_SESSION_DIR = SESSIONS_DIR / "mr_sessions"
 
 DEFAULTS = {
     "model":            "ollama/gemma4:e4b",
-    "max_tokens":       40000,
+    "max_tokens":       40000,    # max OUTPUT tokens per response (NOT the context window)
+    # Context-window override in tokens. 0 = use the model/provider default.
+    # Drives the prompt % indicator, /context, and the compaction trigger. Set
+    # via `/config context_window=<N>` to correct a stale provider default for
+    # the session. WARNING: setting it ABOVE the model's real window disables the
+    # compaction safety net — the API may then reject oversized prompts.
+    "context_window":   0,
     "permission_mode":  "auto",   # auto | accept-all | manual
     "verbose":          False,
     # Tri-state: None = unset (use provider default), True = ON, False = explicit OFF.

--- a/commands/config_cmd.py
+++ b/commands/config_cmd.py
@@ -126,6 +126,20 @@ def cmd_config(args: str, _state, config) -> bool:
         config[key] = val
         save_config(config)
         ok(f"Set {key} = {val!r}")
+        if key == "context_window" and isinstance(val, int) and not isinstance(val, bool) and val > 0:
+            # The override drives the prompt %, /context, AND the compaction
+            # trigger. Warn if it exceeds the model's real window, since that
+            # disables compaction and the API may reject oversized prompts.
+            from compaction import get_context_limit
+            # Real window with the override forced off (keeps custom_base_url so
+            # custom/vLLM endpoints still get their live lookup).
+            real = get_context_limit(config.get("model", ""), {**config, "context_window": 0})
+            if real and val > real:
+                warn(f"context_window={val:,} exceeds the model's real window "
+                     f"(~{real:,}); compaction won't fire before the real limit, "
+                     "so the API may reject oversized prompts. Use this only to "
+                     "correct a wrong default.")
+            info("Takes effect on the next prompt (no restart needed).")
     else:
         k = args.strip()
         v = config.get(k, "(not set)")

--- a/compaction.py
+++ b/compaction.py
@@ -63,14 +63,28 @@ def get_context_limit(model: str, config: dict | None = None) -> int:
     custom/vLLM endpoints get a live /v1/models lookup instead of falling
     back to the stale 128000 default.
 
+    A positive ``context_window`` in config overrides the looked-up default
+    (set via ``/config context_window=<N>``). This is deliberately distinct from
+    ``max_tokens`` (the output cap): the override lets a user correct a stale
+    provider default for the session and applies consistently to the prompt %,
+    /context, and the compaction trigger. It is bidirectional — a smaller value
+    forces earlier compaction; a larger value can disable it (the caller should
+    warn about that footgun). Scope: it applies wherever ``config`` is passed —
+    the prompt %, /context, the compaction trigger, AND the per-call output-token
+    cap (providers shares this parser via ``context_window_override``). Only
+    auto-fanout sizing, called without ``config``, still uses the registry window.
+
     Args:
         model: model string (e.g. "claude-opus-4-6", "ollama/llama3.3",
                "custom/qwen2.5-72b")
-        config: optional agent config dict; reads custom_base_url and
-                custom_api_key if provider is 'custom'
+        config: optional agent config dict; reads context_window override, plus
+                custom_base_url / custom_api_key if provider is 'custom'
     Returns:
         context limit in tokens
     """
+    override = providers.context_window_override(config)
+    if override > 0:
+        return override
     provider_name = providers.detect_provider(model)
     base_url = ""
     api_key = ""

--- a/providers.py
+++ b/providers.py
@@ -447,6 +447,27 @@ def get_model_context_window(provider: str, model: str,
     return 128000
 
 
+def context_window_override(config) -> int:
+    """Parse a user-set ``context_window`` from config.
+
+    Returns a positive token count, or 0 when unset/zero/invalid. This is the
+    single source of truth for the override so it stays consistent across the
+    prompt %/compaction limit (compaction.get_context_limit) AND the per-call
+    output-token cap below. A bool (``/config context_window=true``) is rejected
+    rather than coerced to 1.
+    """
+    if not config:
+        return 0
+    raw = config.get("context_window", 0)
+    if isinstance(raw, bool):
+        return 0
+    try:
+        override = int(raw or 0)
+    except (TypeError, ValueError):
+        return 0
+    return override if override > 0 else 0
+
+
 def dynamic_cap_max_tokens(
     messages: list,
     system,
@@ -955,6 +976,9 @@ def stream_anthropic(
     # Per-call dynamic cap: shrink max_tokens when the current prompt is already
     # large, so input + output never exceeds the model's context window.
     _ctx_window = get_model_context_window("anthropic", model)
+    _ov = context_window_override(config)
+    if _ov:
+        _ctx_window = _ov
     _mt = dynamic_cap_max_tokens(messages, system, tool_schemas, _ctx_window, _mt)
     kwargs = {
         "model":      model,
@@ -1087,6 +1111,9 @@ def stream_openai_compat(
         # local models (qwen2.5, mistral) where the static cap alone is not
         # enough — input grows turn-by-turn.
         _ctx_window = get_model_context_window(_prov, model, base_url, api_key)
+        _ov = context_window_override(config)
+        if _ov:
+            _ctx_window = _ov
         # Pass the system prompt as a single-element list so dynamic_cap counts it.
         val = dynamic_cap_max_tokens(messages, system, kwargs.get("tools"), _ctx_window, val)
         # Newer OpenAI models (o1/o3/o4/gpt-5 family) dropped max_tokens in favour of
@@ -1427,6 +1454,9 @@ def stream_litellm(
         prov_cap = PROVIDERS["litellm"].get("max_completion_tokens")
         val = min(_effective_mt, prov_cap) if prov_cap else _effective_mt
         _ctx_window = get_model_context_window("litellm", model)
+        _ov = context_window_override(config)
+        if _ov:
+            _ctx_window = _ov
         val = dynamic_cap_max_tokens(messages, system, kwargs.get("tools"), _ctx_window, val)
         kwargs["max_tokens"] = val
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -126,6 +126,20 @@ class TestGetContextLimit:
         # than the provider-level 128000 default.
         assert get_context_limit("ollama/llama3.3") == 131072
 
+    def test_context_window_override_takes_priority(self):
+        # A positive context_window in config overrides the model default — both
+        # larger (correct a stale default) and smaller (force earlier compaction).
+        assert get_context_limit("deepseek-chat", {"context_window": 1_000_000}) == 1_000_000
+        assert get_context_limit("claude-opus-4-6", {"context_window": 50_000}) == 50_000
+
+    def test_context_window_override_ignored_when_unset_or_zero(self):
+        # 0 / missing / non-numeric → fall back to the model default, never crash.
+        assert get_context_limit("deepseek-chat", {"context_window": 0}) == 128000
+        assert get_context_limit("deepseek-chat", {}) == 128000
+        assert get_context_limit("deepseek-chat", {"context_window": "oops"}) == 128000
+        # max_tokens must NOT be treated as the context window (kept distinct).
+        assert get_context_limit("deepseek-chat", {"max_tokens": 1_000_000}) == 128000
+
 
 # ── snip_old_tool_results ─────────────────────────────────────────────────
 

--- a/tests/test_context_window_cap.py
+++ b/tests/test_context_window_cap.py
@@ -184,3 +184,32 @@ class TestQwen32kRegression:
         )
         # The whole point: input_est + capped must fit under ctx with safety.
         assert input_est + capped <= ctx - 1024 + 1  # +1 for floor() rounding
+
+
+# ── context_window user override (single source for % / compaction / cap) ──
+
+class TestContextWindowOverride:
+    def test_parses_positive_and_rejects_junk(self):
+        assert providers.context_window_override({"context_window": 1_000_000}) == 1_000_000
+        assert providers.context_window_override({"context_window": "1000000"}) == 1_000_000
+        assert providers.context_window_override({"context_window": 60_000}) == 60_000
+        # unset / zero / negative / non-numeric / bool / None config → 0 (no override)
+        assert providers.context_window_override({"context_window": 0}) == 0
+        assert providers.context_window_override({}) == 0
+        assert providers.context_window_override({"context_window": -5}) == 0
+        assert providers.context_window_override({"context_window": "oops"}) == 0
+        assert providers.context_window_override({"context_window": True}) == 0
+        assert providers.context_window_override(None) == 0
+        # max_tokens (output cap) must NOT be read as the context window
+        assert providers.context_window_override({"max_tokens": 1_000_000}) == 0
+
+    def test_override_flows_to_both_limit_and_output_cap(self):
+        # get_context_limit (drives % + compaction) honors the override...
+        assert compaction.get_context_limit("deepseek-chat", {"context_window": 500_000}) == 500_000
+        # ...and the same parser is what the send paths apply to the cap window,
+        # so an input that fits 500k no longer gets its output floored as if 128k.
+        cfg = {"context_window": 500_000}
+        eff_ctx = providers.context_window_override(cfg) or providers.get_model_context_window(
+            "deepseek", "deepseek-chat"
+        )
+        assert eff_ctx == 500_000


### PR DESCRIPTION
The prompt's context-usage % and the compaction trigger derive from the model's context window, which previously could only be a hardcoded provider default — and max_tokens (the OUTPUT cap) does not change it. Add a dedicated, session-settable override.

- cc_config.py: new DEFAULTS key context_window (0 = use the model default).
- providers.context_window_override(config): single source that parses the override (positive int wins; 0/unset/negative/non-numeric/bool -> 0).
- compaction.get_context_limit(): honors the override, kept distinct from max_tokens. Bidirectional — smaller forces earlier compaction, larger corrects a stale default.
- providers.py send paths: apply the same override to the per-call output-cap window (dynamic_cap_max_tokens) so %, compaction, and the cap stay consistent. No-op when unset, so existing behavior is unchanged.
- /config context_window=<N>: warns when it exceeds the model's real window (disables compaction -> API may reject oversized prompts) and notes it takes effect on the next prompt (no restart).

Read live each prompt, so changing model or context_window updates the % with no restart. Tests cover parsing, both-direction overrides, and that max_tokens is never read as the context window.