### PR TITLE
test: regenerate golden prompt fixture for /quiet command

### DIFF
--- a/tests/fixtures/golden_default_prompt.txt
+++ b/tests/fixtures/golden_default_prompt.txt
@@ -138,6 +138,7 @@ These commands the **user** can invoke at the REPL prompt — they are NOT tools
 - `/plugin` `[install | uninstall | enable | disable | disable-all | update | recommend | info]` — Manage plugins
 - `/proactive` `[off]` — Manage proactive background watcher
 - `/qq` `[<appid> <secret> | stop | status]` — QQ bot bridge (botpy SDK)
+- `/quiet` — Toggle compact tool display
 - `/quit` — Exit (alias for /exit)
 - `/resume` — Resume last session
 - `/rewind` `[clear]` — Rewind to checkpoint (alias)


### PR DESCRIPTION
The /quiet slash command (added in 72b47ab) is auto-included in the system prompt's command list, causing test_default_prompt_matches_golden to drift from the golden fixture. Regenerated the fixture so CI passes.