### PR TITLE
ci: fix package-smoke for the cheetahclaws package layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,23 +52,34 @@ jobs:
           python -c "
           import sys, importlib
 
-          # Top-level modules from pyproject.toml py-modules
+          # The package + its single-file submodules (everything now lives
+          # under the cheetahclaws package — see pyproject [packages.find]).
           modules = [
-              'cheetahclaws', 'agent', 'agent_runner', 'bootstrap',
-              'circuit_breaker', 'cloudsave', 'compaction', 'config',
-              'context', 'health', 'jobs', 'logging_utils', 'memory',
-              'providers', 'quota', 'runtime', 'skills', 'subagent',
-              'tmux_tools', 'tool_registry',
+              'cheetahclaws',
+              'cheetahclaws.agent', 'cheetahclaws.agent_runner',
+              'cheetahclaws.bootstrap', 'cheetahclaws.circuit_breaker',
+              'cheetahclaws.cloudsave', 'cheetahclaws.compaction',
+              'cheetahclaws.config', 'cheetahclaws.context',
+              'cheetahclaws.health', 'cheetahclaws.jobs',
+              'cheetahclaws.logging_utils', 'cheetahclaws.memory',
+              'cheetahclaws.providers', 'cheetahclaws.quota',
+              'cheetahclaws.runtime', 'cheetahclaws.skills',
+              'cheetahclaws.subagent', 'cheetahclaws.tmux_tools',
+              'cheetahclaws.tool_registry',
           ]
 
-          # Packages from pyproject.toml packages
+          # Sub-packages.
           packages = [
-              'tools', 'tools.security', 'tools.fs', 'tools.shell',
-              'tools.web', 'tools.notebook', 'tools.diagnostics',
-              'tools.interaction',
-              'mcp_client', 'monitor', 'multi_agent', 'plugin', 'skill', 'task',
-              'voice', 'video', 'checkpoint', 'ui', 'bridges', 'commands',
-              'modular',
+              'cheetahclaws.tools', 'cheetahclaws.tools.security',
+              'cheetahclaws.tools.fs', 'cheetahclaws.tools.shell',
+              'cheetahclaws.tools.web', 'cheetahclaws.tools.notebook',
+              'cheetahclaws.tools.diagnostics', 'cheetahclaws.tools.interaction',
+              'cheetahclaws.mcp_client', 'cheetahclaws.monitor',
+              'cheetahclaws.multi_agent', 'cheetahclaws.plugin',
+              'cheetahclaws.skill', 'cheetahclaws.task', 'cheetahclaws.voice',
+              'cheetahclaws.video', 'cheetahclaws.checkpoint', 'cheetahclaws.ui',
+              'cheetahclaws.bridges', 'cheetahclaws.commands',
+              'cheetahclaws.modular',
           ]
 
           failed = []


### PR DESCRIPTION
The smoke job imported bare top-level module names (config, tools, providers, …), which no longer exist after everything moved under the cheetahclaws package — so the job failed on the merged packagify change. Prefix the module/package lists with cheetahclaws. (same fix already applied to tests/test_packaging.py). The entry-point check `from cheetahclaws import main` still works via the package's lazy __getattr__ proxy. Verified: all 41 imports + entry point OK locally.