### PR TITLE
fix(memory): activate MemoryVerify in prompt; anchor manifest to veri…

### DIFF
--- a/cheetahclaws/memory/scan.py
+++ b/cheetahclaws/memory/scan.py
@@ -48,7 +48,12 @@ class MemoryHeader:
 # ── Scanning ───────────────────────────────────────────────────────────────
 
 def scan_memory_dir(mem_dir: Path, scope: str) -> list[MemoryHeader]:
-    """Scan a single memory directory and return headers sorted newest-first.
+    """Scan a single memory directory and return headers, freshest-first.
+
+    "Freshest" = most recently verified (verified_epoch: last_verified ->
+    created -> mtime), matching how MemorySearch ranks. Anchoring to
+    verification rather than mtime keeps a mere retrieval from reordering the
+    injected manifest.
 
     Reads only the frontmatter (first ~30 lines) for efficiency.
     Silently skips unreadable files. Caps at MAX_MEMORY_FILES entries.
@@ -79,12 +84,16 @@ def scan_memory_dir(mem_dir: Path, scope: str) -> list[MemoryHeader]:
         except Exception:
             continue
 
-    headers.sort(key=lambda h: h.mtime_s, reverse=True)
+    headers.sort(key=lambda h: verified_epoch(h.last_verified, h.created, h.mtime_s),
+                 reverse=True)
     return headers[:MAX_MEMORY_FILES]
 
 
 def scan_all_memories() -> list[MemoryHeader]:
-    """Scan both user and project memory directories, merged newest-first."""
+    """Scan both user and project memory directories, merged freshest-first.
+
+    Freshest = most recently verified (see scan_memory_dir / verified_epoch).
+    """
     user_dir = get_memory_dir("user")
     proj_dir = get_memory_dir("project")
 
@@ -92,7 +101,8 @@ def scan_all_memories() -> list[MemoryHeader]:
     proj_headers = scan_memory_dir(proj_dir, "project")
 
     combined = user_headers + proj_headers
-    combined.sort(key=lambda h: h.mtime_s, reverse=True)
+    combined.sort(key=lambda h: verified_epoch(h.last_verified, h.created, h.mtime_s),
+                  reverse=True)
     return combined[:MAX_MEMORY_FILES]
 
 
@@ -198,7 +208,9 @@ def format_memory_manifest(headers: list[MemoryHeader]) -> str:
     lines = []
     for h in headers:
         tag = f"[{h.type}/{h.scope}]" if h.type else f"[{h.scope}]"
-        age = memory_age_str(h.mtime_s)
+        # Age since last verified (claim freshness), not since file edit — keeps
+        # the manifest consistent with verified_epoch-anchored staleness.
+        age = memory_age_str(verified_epoch(h.last_verified, h.created, h.mtime_s))
         if h.description:
             lines.append(f"- {tag} {h.filename} ({age}): {h.description}")
         else:

--- a/cheetahclaws/memory/types.py
+++ b/cheetahclaws/memory/types.py
@@ -83,4 +83,13 @@ anything already in CLAUDE.md, or ephemeral task state.
 
 **Before recommending from memory**: A memory naming a file, function, or flag may be stale.
 Verify it still exists before acting on it. For current state, prefer `git log` or reading code.
+
+**Keeping memory fresh (important)**: Retrieving a memory does **not** make it fresh — only
+re-checking its claim against the live code/environment does. Memories you don't re-verify keep
+the "stale" flag and lose retrieval ranking over time, on purpose.
+- If you confirm a memory's claim still holds, call **MemoryVerify** on it. That is the only thing
+  that clears its stale flag and restores its ranking — a plain MemorySearch never does.
+- If the claim no longer holds, fix it with **MemorySave** (overwrite) or drop it with **MemoryDelete**
+  instead of verifying.
+Do this whenever you act on a memory that the system flagged as stale and found still correct.
 """.format(format_example=MEMORY_FORMAT_EXAMPLE)


### PR DESCRIPTION
…fied_epoch

Follow-up to #150. That PR made staleness explicit (only MemoryVerify refreshes it) but left two gaps:

1. The memory system prompt told the model to verify a memory before acting on it, but never mentioned the MemoryVerify tool. Without that, no memory ever gets re-verified, so still-correct old memories keep the stale flag and decay in ranking forever — the "保住老而正确的记忆" half of #150 stayed dormant. Add explicit guidance: after confirming a claim still holds call MemoryVerify (the only thing that clears the stale flag); if it no longer holds, MemorySave or MemoryDelete instead.

2. MemorySearch ranks by verified_epoch, but the always-injected memory manifest still sorted and aged by raw mtime. Anchor scan_memory_dir / scan_all_memories ordering and format_memory_manifest age to verified_epoch too, so the manifest reflects claim freshness consistently. Falls back to mtime when no date fields exist, so legacy files are unchanged.

Existing test_memory.py + test_memory_staleness.py (38 tests) stay green.