### PR TITLE
feat(permissions): add accept-edits mode; expose plan; fix auto descr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Claude Code is a powerful, production-grade AI coding assistant — but its sour
 | Context compression | Four cooperating layers — dynamic `max_tokens` cap, per-model context-window registry, two-layer snip + AI summarize at 70%, and auto-fanout for oversized tool outputs. [Details](docs/guides/reference.md) |
 | Persistent memory | Dual-scope (user + project), 4 types, confidence/source metadata, conflict detection, recency-weighted search, `/memory consolidate` |
 | Multi-agent | Spawn typed sub-agents (coder/reviewer/researcher/…), git-worktree isolation, background mode |
-| Permission system | `auto` / `accept-all` / `manual` / `plan` modes |
+| Permission system | `auto` / `accept-edits` / `accept-all` / `manual` / `plan` modes (`accept-edits` = auto-run edits, still ask for other Bash; hard denylist blocks host-destroying commands in every mode) |
 | Checkpoints & plan mode | Auto-snapshot conversation + files each turn (`/checkpoint`, `/rewind`); `/plan` read-only analysis mode |
 | Slash commands & themes | 50+ slash commands with Tab-complete; `/theme` offers 15 curated palettes |
 | Brainstorm → Worker | `/brainstorm` runs an N-persona debate → `todo_list.txt`; `/worker` auto-implements the pending tasks |

--- a/cheetahclaws/agent.py
+++ b/cheetahclaws/agent.py
@@ -654,7 +654,14 @@ def _check_permission(tc: dict, config: dict) -> bool:
             return _is_safe_bash(tc["input"].get("command", ""))
         return True  # reads are fine
 
-    # "auto" mode: only ask for writes and non-safe bash
+    # "accept-edits" mode: same as "auto", but file edits are pre-approved.
+    # Bash and everything else still follow the auto rules below, so a
+    # non-allow-listed shell command is still prompted (and the hard denylist
+    # still applies at execution time).
+    if perm_mode == "accept-edits" and name in ("Write", "Edit", "NotebookEdit"):
+        return True
+
+    # "auto" mode (and accept-edits fall-through): only ask for writes and non-safe bash
     if name in ("Read", "Glob", "Grep", "WebFetch", "WebSearch"):
         return True
     if name == "Bash":

--- a/cheetahclaws/cli.py
+++ b/cheetahclaws/cli.py
@@ -622,7 +622,7 @@ _CMD_META: dict[str, tuple[str, list[str]]] = {
     "verbose":     ("Toggle verbose output",              []),
     "quiet":       ("Toggle compact tool display",        []),
     "thinking":    ("Toggle extended thinking",           []),
-    "permissions": ("Set permission mode",                ["auto", "accept-all", "manual"]),
+    "permissions": ("Set permission mode",                ["auto", "accept-edits", "accept-all", "manual", "plan"]),
     "cwd":         ("Show / change working directory",    []),
     "skills":      ("List available skills",              []),
     "memory":      ("Search / list / consolidate memories", ["consolidate"]),

--- a/cheetahclaws/commands/config_cmd.py
+++ b/cheetahclaws/commands/config_cmd.py
@@ -179,11 +179,13 @@ def cmd_thinking(_args: str, _state, config) -> bool:
 def cmd_permissions(args: str, _state, config) -> bool:
     from cheetahclaws.config import save_config
     from cheetahclaws.tools import ask_input_interactive
-    modes = ["auto", "accept-all", "manual"]
+    modes = ["auto", "accept-edits", "accept-all", "manual", "plan"]
     mode_desc = {
-        "auto":       "Prompt for each tool call (default)",
-        "accept-all": "Allow all tool calls silently",
-        "manual":     "Prompt for each tool call (strict)",
+        "auto":         "Auto-run reads + allow-listed Bash; ask before edits and other commands (default)",
+        "accept-edits": "Like auto, but also auto-run file edits (Write/Edit); other Bash still asks",
+        "accept-all":   "Run everything without asking (host-destroying commands are still hard-blocked)",
+        "manual":       "Ask before every tool call, including reads",
+        "plan":         "Read-only: reads + safe Bash run, all edits/writes are refused (see /plan for the plan-file workflow)",
     }
     if not args.strip():
         current = config.get("permission_mode", "auto")

--- a/cheetahclaws/prompts/base/default.md
+++ b/cheetahclaws/prompts/base/default.md
@@ -81,15 +81,20 @@ Return control to the user when:
 - Required information is **genuinely** unrecoverable from the workspace (e.g. an external API key, a stakeholder decision, intent that no amount of exploration could disambiguate). Use AskUserQuestion only after you have first searched for the answer with tool calls — never as a substitute for `ls`, Glob, or Read.
 
 # Safe vs Unsafe Actions
-- **Safe** under `auto` permission mode — proceed without asking:
+- Under `auto` permission mode (the default), the harness **auto-runs without asking**:
   - Read / Grep / Glob / WebFetch / WebSearch (read-only)
-  - Edit on files covered by the checkpoint system (reversible)
   - Bash commands on the allow-list (`git status`, `ls`, `python -c`, etc.)
-- **Unsafe** — always ask first, even under `accept-all`:
-  - `rm -rf`, `rm` on anything outside `.cache` / `/tmp`
-  - `git push --force`, `git reset --hard origin/main`, `git clean -fd`
-  - Credential-bearing `curl`, any write to production endpoints
-  - Any action on files outside `allowed_root`
+- Under `auto`, the harness **prompts the user before running**: `Write` / `Edit` (even though the
+  checkpoint system makes them reversible) and any `Bash` command not on the allow-list. Don't
+  assume an edit will go through silently — it is confirmed first.
+- Other modes: `accept-edits` is like `auto` but also auto-runs `Write`/`Edit` (other Bash still
+  prompts); `accept-all` runs everything without prompting; `manual` prompts for every call
+  including reads; `plan` is read-only (edits/writes are refused except to the plan file).
+- **Refused in every mode** (a hard denylist, not a prompt): host-destroying commands such as
+  `rm -rf /`, `mkfs`, `dd` to a raw disk device, `chmod -R 777 /`, and fork bombs.
+- Treat these as dangerous — call them out and confirm intent before proposing them, regardless of
+  mode: `git push --force`, `git reset --hard origin/main`, `git clean -fd`, credential-bearing
+  `curl`, writes to production endpoints, any action on files outside `allowed_root`.
 - When in doubt about reversibility, ask.
 
 # Multi-Agent Guidelines

--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -22,7 +22,7 @@ and indexed in the [README Documentation section](../../README.md#documentation)
 | Multi-agent | Spawn typed sub-agents (coder/reviewer/researcher/…), git worktree isolation, background mode |
 | Skills | Built-in `/commit` · `/review` + custom markdown skills with argument substitution and fork/inline execution |
 | Plugin tools | Register custom tools via `tool_registry.py` |
-| Permission system | `auto` / `accept-all` / `manual` / `plan` modes |
+| Permission system | `auto` / `accept-edits` / `accept-all` / `manual` / `plan` modes. `accept-edits` auto-runs file edits but still prompts for non-allow-listed Bash (the middle ground between `auto` and `accept-all`); a hard denylist blocks host-destroying commands in every mode |
 | Checkpoints | Auto-snapshot conversation + file state after each turn; `/checkpoint` to list, `/checkpoint <id>` to rewind; `/rewind` alias; 100-snapshot sliding window |
 | Plan mode | `/plan <desc>` enters read-only analysis mode; Claude writes only to the plan file; `EnterPlanMode` / `ExitPlanMode` agent tools for autonomous planning |
 | 50+ slash commands | `/model` · `/config` · `/save` · `/cost` · `/memory` · `/skills` · `/agents` · `/voice` · `/proactive` · `/checkpoint` · `/plan` · `/compact` · `/status` · `/doctor` · `/theme` · … |

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -71,7 +71,7 @@ Type `/` and press **Tab** to see all commands with descriptions. Continue typin
 | `/quiet` | Toggle compact tool display — hide per-tool execution lines and show one summary line per turn (on by default; `/verbose` overrides it) |
 | `/thinking` | Toggle Extended Thinking (Claude only) |
 | `/permissions` | Show current permission mode |
-| `/permissions <mode>` | Set permission mode: `auto` / `accept-all` / `manual` |
+| `/permissions <mode>` | Set permission mode: `auto` / `accept-edits` / `accept-all` / `manual` / `plan` |
 | `/cwd` | Show current working directory |
 | `/cwd <path>` | Change working directory |
 | `/memory` | List all persistent memories |
@@ -350,10 +350,13 @@ Keys are saved to `~/.cheetahclaws/config.json` and loaded automatically on next
 
 | Mode | Behavior |
 |---|---|
-| `auto` (default) | Read-only operations always allowed. Prompts before Bash commands and file writes. |
-| `accept-all` | Never prompts. All operations proceed automatically. |
+| `auto` (default) | Reads + allow-listed Bash run automatically; prompts before file writes (`Write`/`Edit`) and any other Bash command. |
+| `accept-edits` | Like `auto`, but also auto-runs file edits (`Write`/`Edit`/`NotebookEdit`); other (non-allow-listed) Bash still prompts. The middle ground between `auto` and `accept-all`. |
+| `accept-all` | Never prompts; all operations proceed automatically. |
 | `manual` | Prompts before every single operation, including reads. |
-| `plan` | Read-only analysis mode. Only the plan file (`.nano_claude/plans/`) is writable. Entered via `/plan <desc>` or the `EnterPlanMode` tool. |
+| `plan` | Read-only analysis mode: reads + safe Bash run, all writes are refused except the plan file. Entered via `/plan <desc>` or the `EnterPlanMode` tool. |
+
+A **hard denylist** (`rm -rf /`, `mkfs`, `dd` to a raw disk device, `chmod -R 777 /`, fork bombs) is refused at execution time in **every** mode — including `accept-all`, and even if you approve it under `manual`.
 
 **When prompted:**
 


### PR DESCRIPTION
…iptions

New `accept-edits` permission mode — the middle ground between `auto` and `accept-all`: auto-runs file edits (Write/Edit/NotebookEdit) but still prompts for non-allow-listed Bash, so destructive shell commands are not silently run (and the hard denylist still applies at execution time). One branch added to _check_permission; reads/Bash keep the auto rules.

Also surfaces the already-implemented `plan` mode in the /permissions menu and tab-completion, and corrects misleading permission text:
- /permissions menu + cli.py hints now list all 5 modes with accurate blurbs.
- System prompt's "Safe vs Unsafe" section previously claimed auto auto-approves checkpoint-protected edits and that unsafe ops are asked "even under accept-all" — both wrong vs _check_permission. Rewritten to match real behavior (auto asks for all edits; accept-all does not ask; only the hard denylist blocks in every mode).
- README / features / reference docs updated with the 5 modes and accept-edits.