### PR TITLE
feat(/image): add CHEETAHCLAWS_IMAGE_OCR opt-out for OCR enrichment

### DIFF
--- a/cheetahclaws/commands/core.py
+++ b/cheetahclaws/commands/core.py
@@ -1041,15 +1041,20 @@ def cmd_image(args: str, state, config) -> Union[bool, tuple]:
     # both the pixels and the exact text (OCR beats vision models at
     # transcribing dense text). Zero-cost no-op when pytesseract/tesseract
     # is not installed or the image has no text.
-    from cheetahclaws.tools.files import ocr_image_bytes
-    ocr_text = ocr_image_bytes(png_bytes)
-    if ocr_text:
-        info(f"🔎 OCR: extracted {len(ocr_text)} chars of text from image")
-        prompt += (
-            "\n\n[Text extracted from the attached image via local OCR — "
-            "verbatim, may contain recognition errors:]\n"
-            f"{ocr_text[:8000]}"
-        )
+    #
+    # OCR runs synchronously and can add noticeable latency on large images;
+    # it also injects possibly-imperfect text alongside the pixels, which a
+    # vision model may not want. Set CHEETAHCLAWS_IMAGE_OCR=0 to disable.
+    if os.environ.get("CHEETAHCLAWS_IMAGE_OCR", "1") != "0":
+        from cheetahclaws.tools.files import ocr_image_bytes
+        ocr_text = ocr_image_bytes(png_bytes)
+        if ocr_text:
+            info(f"🔎 OCR: extracted {len(ocr_text)} chars of text from image")
+            prompt += (
+                "\n\n[Text extracted from the attached image via local OCR — "
+                "verbatim, may contain recognition errors:]\n"
+                f"{ocr_text[:8000]}"
+            )
 
     return ("__image__", prompt)
 

--- a/tests/test_image_ocr.py
+++ b/tests/test_image_ocr.py
@@ -143,3 +143,34 @@ def test_cmd_image_still_sets_pending_image(monkeypatch, _clipboard_image):
 
     sctx = runtime.get_ctx(config)
     assert sctx.pending_image, "pending_image should still carry the base64 PNG"
+
+
+def test_cmd_image_ocr_disabled_via_env(monkeypatch, _clipboard_image):
+    """CHEETAHCLAWS_IMAGE_OCR=0 skips OCR entirely (no latency, no injection)."""
+    from cheetahclaws.commands import core as core_mod
+
+    called = {"n": 0}
+
+    def _tracker(*_a, **_k):
+        called["n"] += 1
+        return "should not be appended"
+
+    monkeypatch.setattr(files_mod, "ocr_image_bytes", _tracker)
+    monkeypatch.setenv("CHEETAHCLAWS_IMAGE_OCR", "0")
+    config = {"_session_id": "test-ocr-5"}
+    result = core_mod.cmd_image("describe", state=None, config=config)
+
+    assert result[1] == "describe"
+    assert called["n"] == 0, "ocr_image_bytes must not run when disabled"
+
+
+def test_cmd_image_ocr_enabled_by_default(monkeypatch, _clipboard_image):
+    """With the env var unset, OCR enrichment stays on (PR default preserved)."""
+    from cheetahclaws.commands import core as core_mod
+
+    monkeypatch.delenv("CHEETAHCLAWS_IMAGE_OCR", raising=False)
+    monkeypatch.setattr(files_mod, "ocr_image_bytes", lambda *_a, **_k: "hello ocr")
+    config = {"_session_id": "test-ocr-6"}
+    result = core_mod.cmd_image("describe", state=None, config=config)
+
+    assert "hello ocr" in result[1]


### PR DESCRIPTION
Local OCR on /image runs synchronously (latency on large images) and injects possibly-imperfect text alongside the pixels, which a vision model may not want. Gate it behind CHEETAHCLAWS_IMAGE_OCR (default on; set to 0 to disable). Adds tests for the disabled and default paths.