### PR TITLE
feat(cli): add /workspace command

### DIFF
--- a/cheetahclaws/cli.py
+++ b/cheetahclaws/cli.py
@@ -30,6 +30,7 @@ Slash commands in REPL:
   /thinking   Toggle extended thinking
   /permissions [mode]  Set permission mode
   /cwd [path] Show or change working directory
+  /workspace [cmd] Manage CheetahClaws workspaces (list/switch/create/delete)
   /compact    Compact conversation history to save context space
   /init       Initialize a CLAUDE.md file in the current directory
   /export [f] Export conversation history to a Markdown file
@@ -237,6 +238,7 @@ from cheetahclaws.commands.config_cmd import (
     cmd_model, cmd_config, cmd_verbose, cmd_thinking, cmd_quiet,
     cmd_permissions, cmd_cwd, _interactive_ollama_picker,
 )
+from cheetahclaws.commands.workspace_cmd import cmd_workspace, _apply_workspace
 
 # ── Core commands ──────────────────────────────────────────────────────────
 from cheetahclaws.commands.core import (
@@ -460,6 +462,7 @@ COMMANDS = {
     "thinking":    cmd_thinking,
     "permissions": cmd_permissions,
     "cwd":         cmd_cwd,
+    "workspace":   cmd_workspace,
     "skills":      cmd_skills,
     "memory":      cmd_memory,
     "agents":      cmd_agents,
@@ -624,6 +627,7 @@ _CMD_META: dict[str, tuple[str, list[str]]] = {
     "thinking":    ("Toggle extended thinking",           []),
     "permissions": ("Set permission mode",                ["auto", "accept-edits", "accept-all", "manual", "plan"]),
     "cwd":         ("Show / change working directory",    []),
+    "workspace":   ("Manage CheetahClaws workspaces",       ["list", "switch", "default", "create", "delete"]),
     "skills":      ("List available skills",              []),
     "memory":      ("Search / list / consolidate memories", ["consolidate"]),
     "agents":      ("Show background agents",             []),
@@ -2014,6 +2018,13 @@ def main():
     from cheetahclaws.providers import detect_provider, PROVIDERS
 
     config = load_config()
+
+    # ── Workspace: start in the last-used workspace (or workspace1) ──────────
+    try:
+        _apply_workspace(config)
+    except Exception as _e:
+        if config.get("verbose", False):
+            warn(f"Could not apply workspace: {_e}")
 
     # Apply persisted console theme (if any) before any output is rendered.
     try:

--- a/cheetahclaws/commands/workspace_cmd.py
+++ b/cheetahclaws/commands/workspace_cmd.py
@@ -1,0 +1,166 @@
+"""commands/workspace_cmd.py — Workspace management for CheetahClaws.
+
+Mirrors the Dulus /workspace slash command so users can switch, list, create,
+and delete isolated working directories under ~/.cheetahclaws/workspaces.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from cheetahclaws.ui.render import info, ok, err, warn
+
+
+_WORKSPACES_DIR: Path = Path.home() / ".cheetahclaws" / "workspaces"
+_DEFAULT_WORKSPACE: str = "workspace1"
+
+
+def _workspace_path(name: str) -> Path:
+    return _WORKSPACES_DIR / name
+
+
+def _ensure_workspace(name: str) -> Path:
+    """Create workspace dir if missing and return its path."""
+    ws = _workspace_path(name)
+    ws.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _list_workspaces() -> list[str]:
+    if not _WORKSPACES_DIR.exists():
+        return []
+    return sorted(p.name for p in _WORKSPACES_DIR.iterdir() if p.is_dir())
+
+
+def _current_workspace_name() -> str | None:
+    """Return the workspace name if cwd is inside ~/.cheetahclaws/workspaces/."""
+    try:
+        cwd = Path.cwd().resolve()
+        root = _WORKSPACES_DIR.resolve()
+        if root in cwd.parents or cwd == root:
+            rel = cwd.relative_to(root)
+            first = rel.parts[0] if rel.parts else None
+            if first and _workspace_path(first).is_dir():
+                return first
+    except Exception:
+        pass
+    return None
+
+
+def _activate_workspace(name: str, config: dict) -> bool:
+    """Change cwd into workspace, create it if missing, and persist as last used."""
+    from cheetahclaws.config import save_config
+    ws = _ensure_workspace(name)
+    try:
+        os.chdir(ws)
+        config["workspace_last"] = name
+        save_config(config)
+        return True
+    except Exception as e:
+        err(f"Could not switch to workspace '{name}': {e}")
+        return False
+
+
+def _apply_workspace(config: dict) -> None:
+    """At boot, move cwd into the last-used workspace (or workspace1)."""
+    last = config.get("workspace_last") or _DEFAULT_WORKSPACE
+    ws = _workspace_path(last)
+    if not ws.exists():
+        _ensure_workspace(last)
+    try:
+        os.chdir(ws)
+        if config.get("verbose", False):
+            info(f"Active workspace: {last}")
+    except Exception as e:
+        warn(f"Could not enter workspace '{last}': {e}")
+
+
+def cmd_workspace(args: str, _state, config) -> bool:
+    """Manage CheetahClaws workspaces under ~/.cheetahclaws/workspaces.
+
+    /workspace                — show current workspace + cwd
+    /workspace current        — same as above
+    /workspace list           — list workspaces
+    /workspace switch <name>  — change to workspace (creates if missing)
+    /workspace default [name] — show or set the startup workspace
+    /workspace create <name>  — create a workspace without switching
+    /workspace delete <name>  — delete a workspace (must be empty)
+    """
+    from cheetahclaws.config import save_config
+    parts = args.strip().split(None, 1)
+    subcmd = parts[0].lower() if parts else "current"
+    rest = parts[1].strip() if len(parts) > 1 else ""
+
+    if subcmd in ("current", "cwd", ""):
+        current = _current_workspace_name()
+        if current:
+            info(f"Workspace: {current}")
+        else:
+            info("You are not inside a CheetahClaws workspace.")
+        info(f"Working directory: {os.getcwd()}")
+        return True
+
+    if subcmd == "list":
+        workspaces = _list_workspaces()
+        current = _current_workspace_name()
+        if not workspaces:
+            info("No workspaces yet. Use /workspace create <name>.")
+            return True
+        info(f"Workspaces in {_WORKSPACES_DIR}:")
+        for w in workspaces:
+            mark = "  → " if w == current else "    "
+            print(f"{mark}{w}")
+        return True
+
+    if subcmd == "switch":
+        if not rest:
+            err("Usage: /workspace switch <name>")
+            return True
+        name = rest.split()[0]
+        if _activate_workspace(name, config):
+            ok(f"Workspace switched to: {name}")
+        return True
+
+    if subcmd == "default":
+        if not rest:
+            current_default = config.get("workspace_last") or _DEFAULT_WORKSPACE
+            info(f"Default workspace: {current_default}")
+            return True
+        name = rest.split()[0]
+        _ensure_workspace(name)
+        config["workspace_last"] = name
+        save_config(config)
+        ok(f"Default workspace set to: {name}")
+        return True
+
+    if subcmd == "create":
+        if not rest:
+            err("Usage: /workspace create <name>")
+            return True
+        name = rest.split()[0]
+        _ensure_workspace(name)
+        ok(f"Workspace created: {name}")
+        return True
+
+    if subcmd == "delete":
+        if not rest:
+            err("Usage: /workspace delete <name>")
+            return True
+        name = rest.split()[0]
+        target = _workspace_path(name)
+        if not target.exists():
+            err(f"Workspace '{name}' does not exist.")
+            return True
+        current = _current_workspace_name()
+        if name == current:
+            err("You cannot delete the workspace you are currently in. Switch first with /workspace switch.")
+            return True
+        try:
+            target.rmdir()
+            ok(f"Workspace deleted: {name}")
+        except OSError as e:
+            err(f"Could not delete '{name}': {e}. Make sure it is empty.")
+        return True
+
+    err(f"Unknown subcommand: /workspace {subcmd}")
+    return True

--- a/tests/fixtures/golden_default_prompt.txt
+++ b/tests/fixtures/golden_default_prompt.txt
@@ -170,3 +170,4 @@ These commands the **user** can invoke at the REPL prompt — they are NOT tools
 - `/web` `[status | --no-auth | --host]` — Start the web terminal / chat UI in background
 - `/wechat` `[stop | status]` — WeChat bridge (iLink Bot API)
 - `/worker` — Auto-implement pending tasks
+- `/workspace` `[list | switch | default | create | delete]` — Manage CheetahClaws workspaces


### PR DESCRIPTION
Adds the /workspace slash command to manage isolated working directories under ~/.cheetahclaws/workspaces. Supports list, switch, default, create and delete, and automatically restores the last-used workspace on startup. Mirrors the Dulus workspace workflow.