### PR TITLE
fix(workspace): make startup chdir opt-in and separate default/last keys

### DIFF
--- a/cheetahclaws/cli.py
+++ b/cheetahclaws/cli.py
@@ -2019,12 +2019,15 @@ def main():
 
     config = load_config()
 
-    # ── Workspace: start in the last-used workspace (or workspace1) ──────────
-    try:
-        _apply_workspace(config)
-    except Exception as _e:
-        if config.get("verbose", False):
-            warn(f"Could not apply workspace: {_e}")
+    # ── Workspace: opt-in. Only chdir into a managed workspace when the user
+    # has enabled it (config workspace_auto=true). Off by default so launching
+    # in a project directory keeps operating on that directory. ───────────────
+    if config.get("workspace_auto", False):
+        try:
+            _apply_workspace(config)
+        except Exception as _e:
+            if config.get("verbose", False):
+                warn(f"Could not apply workspace: {_e}")
 
     # Apply persisted console theme (if any) before any output is rendered.
     try:

--- a/cheetahclaws/commands/workspace_cmd.py
+++ b/cheetahclaws/commands/workspace_cmd.py
@@ -61,18 +61,32 @@ def _activate_workspace(name: str, config: dict) -> bool:
         return False
 
 
+def _startup_workspace(config: dict) -> str:
+    """Which workspace to enter at boot.
+
+    Prefers the explicit default (`/workspace default`), then the last-used
+    workspace (`/workspace switch`), then the built-in fallback. Setting a
+    default is sticky: switching workspaces no longer clobbers it.
+    """
+    return (
+        config.get("workspace_default")
+        or config.get("workspace_last")
+        or _DEFAULT_WORKSPACE
+    )
+
+
 def _apply_workspace(config: dict) -> None:
-    """At boot, move cwd into the last-used workspace (or workspace1)."""
-    last = config.get("workspace_last") or _DEFAULT_WORKSPACE
-    ws = _workspace_path(last)
+    """At boot, move cwd into the startup workspace (see _startup_workspace)."""
+    target = _startup_workspace(config)
+    ws = _workspace_path(target)
     if not ws.exists():
-        _ensure_workspace(last)
+        _ensure_workspace(target)
     try:
         os.chdir(ws)
         if config.get("verbose", False):
-            info(f"Active workspace: {last}")
+            info(f"Active workspace: {target}")
     except Exception as e:
-        warn(f"Could not enter workspace '{last}': {e}")
+        warn(f"Could not enter workspace '{target}': {e}")
 
 
 def cmd_workspace(args: str, _state, config) -> bool:
@@ -123,12 +137,14 @@ def cmd_workspace(args: str, _state, config) -> bool:
 
     if subcmd == "default":
         if not rest:
-            current_default = config.get("workspace_last") or _DEFAULT_WORKSPACE
+            current_default = config.get("workspace_default") or _DEFAULT_WORKSPACE
             info(f"Default workspace: {current_default}")
+            if not config.get("workspace_auto", False):
+                info("(startup auto-switch is off; enable with /config workspace_auto=true)")
             return True
         name = rest.split()[0]
         _ensure_workspace(name)
-        config["workspace_last"] = name
+        config["workspace_default"] = name
         save_config(config)
         ok(f"Default workspace set to: {name}")
         return True

--- a/cheetahclaws/config.py
+++ b/cheetahclaws/config.py
@@ -35,6 +35,18 @@ DEFAULTS = {
     "max_concurrent_agents": 3,
     "session_daily_limit":   10000,    # max sessions kept per day in daily/
     "session_history_limit": 100000,  # max sessions kept in history.json
+    # ── Workspaces ──────────────────────────────────────────────────────────
+    # workspace_auto: when True, the CLI chdirs into a workspace under
+    #   ~/.cheetahclaws/workspaces on startup. Default False so launching in a
+    #   project directory keeps operating on that directory (opt-in isolation).
+    "workspace_auto":    False,
+    # workspace_default: the workspace entered at startup when workspace_auto is
+    #   on. null → fall back to workspace_last, then "workspace1". Set via
+    #   `/workspace default <name>`; NOT overwritten by `/workspace switch`.
+    "workspace_default": None,
+    # workspace_last: the most recently switched-to workspace (updated by
+    #   `/workspace switch`). Used as the startup fallback when no default is set.
+    "workspace_last":    None,
     # ── Security settings ──────────────────────────────────────────────────
     # allowed_root: restrict file operations (Read/Write/Edit/Glob/Grep) to this
     # directory tree.  null = unrestricted (CLI default).  Set to the project

--- a/tests/test_workspace_cmd.py
+++ b/tests/test_workspace_cmd.py
@@ -1,0 +1,145 @@
+"""Unit tests for commands/workspace_cmd.
+
+Coverage:
+  * create / list / switch / delete round-trips against a tmp workspace root
+  * current-workspace detection from cwd
+  * startup workspace precedence (default > last > builtin fallback)
+  * `default` and `switch` write DISTINCT config keys (regression: they used
+    to share `workspace_last`, so setting a default was clobbered by a switch)
+  * `_apply_workspace` is a no-op-safe boot helper that chdirs correctly
+
+All filesystem state is redirected to tmp_path via the module-level
+`_WORKSPACES_DIR` (computed from Path.home() at import time), and config
+persistence is stubbed so tests never touch the real ~/.cheetahclaws.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cheetahclaws.commands import workspace_cmd as ws
+
+
+@pytest.fixture
+def wsroot(tmp_path, monkeypatch):
+    """Redirect the workspace root to an isolated tmp dir and stub save_config.
+
+    Restores the original cwd after each test (the command chdirs around).
+    """
+    root = tmp_path / "workspaces"
+    monkeypatch.setattr(ws, "_WORKSPACES_DIR", root)
+    # cmd_workspace / _activate_workspace import save_config from cheetahclaws.config
+    import cheetahclaws.config as _cfg
+    monkeypatch.setattr(_cfg, "save_config", lambda cfg: None)
+    origin = Path.cwd()
+    # Start outside any workspace so current-detection is unambiguous.
+    monkeypatch.chdir(tmp_path)
+    try:
+        yield root
+    finally:
+        os.chdir(origin)
+
+
+def _run(sub, config):
+    return ws.cmd_workspace(sub, None, config)
+
+
+# ── create / list ───────────────────────────────────────────────────────────
+
+def test_create_and_list(wsroot):
+    config = {}
+    assert _run("create alpha", config) is True
+    assert _run("create beta", config) is True
+    assert (wsroot / "alpha").is_dir()
+    assert ws._list_workspaces() == ["alpha", "beta"]
+
+
+def test_create_requires_name(wsroot, capsys):
+    assert _run("create", {}) is True
+    assert not wsroot.exists() or not any(wsroot.iterdir())
+
+
+# ── switch / current detection ───────────────────────────────────────────────
+
+def test_switch_creates_and_chdirs(wsroot):
+    config = {}
+    _run("switch gamma", config)
+    assert Path.cwd().resolve() == (wsroot / "gamma").resolve()
+    # switch records last-used, NOT the sticky default
+    assert config.get("workspace_last") == "gamma"
+    assert config.get("workspace_default") is None
+
+
+def test_current_workspace_detection(wsroot):
+    config = {}
+    _run("switch delta", config)
+    assert ws._current_workspace_name() == "delta"
+
+
+def test_current_none_outside_workspace(wsroot):
+    assert ws._current_workspace_name() is None
+
+
+# ── default vs switch: distinct keys (regression) ────────────────────────────
+
+def test_default_and_switch_use_distinct_keys(wsroot):
+    """Setting a default must survive a later switch."""
+    config = {}
+    _run("default proj", config)
+    assert config["workspace_default"] == "proj"
+    _run("switch scratch", config)
+    # switch changed last-used but left the default intact
+    assert config["workspace_default"] == "proj"
+    assert config["workspace_last"] == "scratch"
+
+
+def test_startup_precedence(wsroot):
+    # default wins over last
+    assert ws._startup_workspace(
+        {"workspace_default": "d", "workspace_last": "l"}
+    ) == "d"
+    # last wins when no default
+    assert ws._startup_workspace({"workspace_last": "l"}) == "l"
+    # builtin fallback when neither set
+    assert ws._startup_workspace({}) == ws._DEFAULT_WORKSPACE
+
+
+# ── delete ───────────────────────────────────────────────────────────────────
+
+def test_delete_empty_workspace(wsroot):
+    config = {}
+    _run("create trash", config)
+    assert (wsroot / "trash").is_dir()
+    _run("delete trash", config)
+    assert not (wsroot / "trash").exists()
+
+
+def test_cannot_delete_current_workspace(wsroot):
+    config = {}
+    _run("switch here", config)
+    _run("delete here", config)
+    # still present because we're inside it
+    assert (wsroot / "here").exists()
+
+
+def test_delete_missing_is_graceful(wsroot):
+    assert _run("delete nope", {}) is True
+
+
+# ── boot helper ──────────────────────────────────────────────────────────────
+
+def test_apply_workspace_chdirs_to_default(wsroot):
+    config = {"workspace_default": "boot"}
+    ws._apply_workspace(config)
+    assert Path.cwd().resolve() == (wsroot / "boot").resolve()
+
+
+def test_apply_workspace_fallback_creates_builtin(wsroot):
+    ws._apply_workspace({})
+    assert (wsroot / ws._DEFAULT_WORKSPACE).is_dir()
+    assert Path.cwd().resolve() == (wsroot / ws._DEFAULT_WORKSPACE).resolve()


### PR DESCRIPTION
- Gate boot-time chdir behind workspace_auto (default off) so launching in a project directory no longer silently switches into a managed workspace.
- Split workspace_default (sticky startup) from workspace_last (most-recent switch) so setting a default survives later /workspace switch calls.
- Register workspace_auto/workspace_default/workspace_last in config DEFAULTS.
- Add tests/test_workspace_cmd.py (12 tests) covering CRUD, current-workspace detection, startup precedence, and the boot helper.