### PR TITLE
Activate Anthropic prompt caching + SDK client reuse (cache-aware cost accounting)

### DIFF
--- a/cheetahclaws/agent.py
+++ b/cheetahclaws/agent.py
@@ -175,6 +175,19 @@ def run(
                 _proj_tokens = (_est_tok(state.messages)
                                 + _est_tok([{"role": "system", "content": system_prompt}]))
                 _proj_cost = _calc_cost(config["model"], _proj_tokens, 0)
+                # Prompt caching bills cache-writes at 1.25x the input rate,
+                # and a full-miss request writes its entire prefix. Reserve
+                # that worst case up front so a permitted call can't overshoot
+                # the cost budget (token projection needs no bump — the
+                # estimate already covers the whole prompt, which the API
+                # merely splits into input/cache_read/cache_write).
+                # is_prompt_cache_active mirrors what stream_anthropic will
+                # really send: once a proxy rejection disables the endpoint,
+                # requests go out raw and the premium must not be reserved.
+                from cheetahclaws.providers import is_prompt_cache_active as _pc_active
+                if (_pc_active(config)
+                        and detect_provider(config.get("model", "")) == "anthropic"):
+                    _proj_cost *= 1.25
             except Exception:
                 _proj_tokens, _proj_cost = 0, 0.0
         try:
@@ -222,6 +235,8 @@ def run(
                         _quota.record_usage(
                             session_id, config["model"],
                             event.in_tokens, event.out_tokens,
+                            cache_read_tokens=getattr(event, "cache_read_tokens", 0),
+                            cache_write_tokens=getattr(event, "cache_write_tokens", 0),
                         )
                 break  # success — exit retry loop
 

--- a/cheetahclaws/commands/core.py
+++ b/cheetahclaws/commands/core.py
@@ -214,11 +214,17 @@ def cmd_context(_args: str, state, config) -> bool:
 
 def cmd_cost(_args: str, state, config) -> bool:
     from cheetahclaws.config import calc_cost
+    cache_read  = getattr(state, "total_cache_read_tokens", 0)
+    cache_write = getattr(state, "total_cache_write_tokens", 0)
     cost = calc_cost(config["model"],
                      state.total_input_tokens,
-                     state.total_output_tokens)
+                     state.total_output_tokens,
+                     cache_read, cache_write)
     info(f"Input tokens:  {state.total_input_tokens:,}")
     info(f"Output tokens: {state.total_output_tokens:,}")
+    if cache_read or cache_write:
+        info(f"Cache read:    {cache_read:,} tokens (0.1x input rate)")
+        info(f"Cache write:   {cache_write:,} tokens (1.25x input rate)")
     info(f"Est. cost:     ${cost:.4f} USD")
     return True
 

--- a/cheetahclaws/config.py
+++ b/cheetahclaws/config.py
@@ -65,6 +65,16 @@ DEFAULTS = {
     # log_file: absolute path or null.  null → stderr (only warn/error visible
     #   at default level).  Point to a file in production for persistent logs.
     "log_file": None,
+    # ── Prompt caching (Anthropic) ─────────────────────────────────────────
+    # prompt_cache: mark cache_control breakpoints on Anthropic requests so
+    #   the provider's prompt cache activates (cache read = 0.1x input price,
+    #   cache write = 1.25x; within-turn tool loops re-send an identical
+    #   prefix 5-50 times, so this is a large input-cost/latency win).
+    #   Escape hatch: set to false when a custom anthropic_endpoint proxy
+    #   rejects cache_control fields (a 400 naming cache_control also
+    #   auto-disables it for the rest of the process). Other providers
+    #   ignore this flag — their caching is implicit server-side.
+    "prompt_cache": True,
     # ── Circuit breaker ────────────────────────────────────────────────────
     # circuit_failure_threshold: consecutive failures (in window) to trip open.
     "circuit_failure_threshold": 5,
@@ -184,6 +194,7 @@ def has_api_key(cfg: dict) -> bool:
     return bool(key)
 
 
-def calc_cost(model: str, in_tokens: int, out_tokens: int) -> float:
+def calc_cost(model: str, in_tokens: int, out_tokens: int,
+              cache_read_tokens: int = 0, cache_write_tokens: int = 0) -> float:
     from cheetahclaws.providers import calc_cost as _cc
-    return _cc(model, in_tokens, out_tokens)
+    return _cc(model, in_tokens, out_tokens, cache_read_tokens, cache_write_tokens)

--- a/cheetahclaws/providers.py
+++ b/cheetahclaws/providers.py
@@ -588,9 +588,15 @@ def get_api_key(provider_name: str, config: dict) -> str:
     return prov.get("api_key", "")
 
 
-def calc_cost(model: str, in_tok: int, out_tok: int) -> float:
+def calc_cost(model: str, in_tok: int, out_tok: int,
+              cache_read_tok: int = 0, cache_write_tok: int = 0) -> float:
+    """Estimate USD cost. Anthropic reports cached tokens separately from
+    input_tokens, priced at 0.1x (read) / 1.25x (write) of the input rate —
+    omitting them would silently under-report spend once prompt caching is
+    active."""
     ic, oc = COSTS.get(bare_model(model), (0.0, 0.0))
-    return (in_tok * ic + out_tok * oc) / 1_000_000
+    cache = (cache_read_tok * 0.1 + cache_write_tok * 1.25) * ic
+    return (in_tok * ic + out_tok * oc + cache) / 1_000_000
 
 
 # ── Native tool-call format interceptors ──────────────────────────────────
@@ -1083,6 +1089,90 @@ def _release_anthropic_client(api_key: str, base_url: str) -> None:
         _close_quietly(stale)
 
 
+# ── Anthropic prompt caching ───────────────────────────────────────────────
+# cache_control breakpoints let Anthropic reuse the shared request prefix
+# (tools → system → history) across the tool loop's sequential calls: reads
+# bill at 0.1x input price, writes at 1.25x, so caching pays off from the
+# second call on any shared prefix (break-even hit-rate ≈ 22%). Three
+# breakpoints of the API's maximum four are used; annotation is strictly
+# copy-on-write because tool_schemas aliases the live registry dicts and
+# messages aliases the neutral session history.
+
+_CACHE_EPHEMERAL = {"type": "ephemeral"}
+
+# Endpoints whose proxy rejected cache_control with a 400 — disabled for the
+# rest of the process so a strict shim degrades to one failed call, not a loop.
+_cache_control_disabled: set[str] = set()
+
+
+def is_prompt_cache_active(config: dict) -> bool:
+    """True when the next Anthropic request will actually carry cache_control.
+
+    Single source of truth shared by stream_anthropic (whether to annotate)
+    and the agent's quota projection (whether to reserve the 1.25x
+    cache-write premium): once a proxy rejection disables an endpoint,
+    requests go out raw, and reserving the premium would wrongly pause a
+    budget that the real request fits within.
+    """
+    if not config.get("prompt_cache", True):
+        return False
+    base_url = config.get("anthropic_endpoint") or "https://api.anthropic.com"
+    return base_url not in _cache_control_disabled
+
+
+def _is_cache_control_rejection(e: Exception) -> bool:
+    """True only for a schema-level rejection of the cache_control field.
+
+    Requires BOTH the field name and a 400/invalid-request signal, so a
+    transient error whose message merely mentions cache_control (e.g. a
+    connection reset mid-request) doesn't permanently disable caching for
+    the endpoint — those errors belong to the agent-level retry loop.
+    """
+    msg = str(e).lower()
+    if "cache_control" not in msg:
+        return False
+    if getattr(e, "status_code", None) == 400:
+        return True
+    return ("400" in msg
+            or "invalid_request" in msg
+            or "bad request" in msg
+            or "unexpected field" in msg)
+
+
+def _apply_anthropic_cache_control(kwargs: dict) -> dict:
+    """Return a copy of the request kwargs with ≤3 cache_control breakpoints:
+    last tool schema, system block, last content block of the final message.
+    Never mutates the input structures. Unexpected shapes skip their
+    breakpoint rather than raise."""
+    out = dict(kwargs)
+
+    tools = out.get("tools")
+    if tools:
+        out["tools"] = [*tools[:-1],
+                        {**tools[-1], "cache_control": dict(_CACHE_EPHEMERAL)}]
+
+    system = out.get("system")
+    if isinstance(system, str) and system:
+        out["system"] = [{"type": "text", "text": system,
+                          "cache_control": dict(_CACHE_EPHEMERAL)}]
+
+    msgs = out.get("messages")
+    if msgs:
+        last = msgs[-1]
+        content = last.get("content")
+        if isinstance(content, str) and content:
+            new_last = {**last, "content": [
+                {"type": "text", "text": content,
+                 "cache_control": dict(_CACHE_EPHEMERAL)}]}
+            out["messages"] = [*msgs[:-1], new_last]
+        elif isinstance(content, list) and content and isinstance(content[-1], dict):
+            new_block = {**content[-1], "cache_control": dict(_CACHE_EPHEMERAL)}
+            new_last = {**last, "content": [*content[:-1], new_block]}
+            out["messages"] = [*msgs[:-1], new_last]
+
+    return out
+
+
 def stream_anthropic(
     api_key: str,
     model: str,
@@ -1116,39 +1206,66 @@ def stream_anthropic(
             "budget_tokens": config.get("thinking_budget", 10000),
         }
 
-    tool_calls = []
-    text       = ""
+    use_cache = is_prompt_cache_active(config)
+    attempts = ([_apply_anthropic_cache_control(kwargs), kwargs]
+                if use_cache else [kwargs])
 
     try:
-        with client.messages.stream(**kwargs) as stream:
-            for event in stream:
-                etype = getattr(event, "type", None)
-                if etype == "content_block_delta":
-                    delta = event.delta
-                    dtype = getattr(delta, "type", None)
-                    if dtype == "text_delta":
-                        text += delta.text
-                        yield TextChunk(delta.text)
-                    elif dtype == "thinking_delta":
-                        yield ThinkingChunk(delta.thinking)
+        for attempt_idx, call_kwargs in enumerate(attempts):
+            tool_calls = []
+            text       = ""
+            yielded    = False
 
-            final = stream.get_final_message()
-            for block in final.content:
-                if block.type == "tool_use":
-                    tool_calls.append({
-                        "id":    block.id,
-                        "name":  block.name,
-                        "input": block.input,
-                    })
+            try:
+                with client.messages.stream(**call_kwargs) as stream:
+                    for event in stream:
+                        etype = getattr(event, "type", None)
+                        if etype == "content_block_delta":
+                            delta = event.delta
+                            dtype = getattr(delta, "type", None)
+                            if dtype == "text_delta":
+                                text += delta.text
+                                yielded = True
+                                yield TextChunk(delta.text)
+                            elif dtype == "thinking_delta":
+                                yielded = True
+                                yield ThinkingChunk(delta.thinking)
 
-            cache_r, cache_w = _anthropic_cache_tokens(final.usage)
-            yield AssistantTurn(
-                text, tool_calls,
-                final.usage.input_tokens,
-                final.usage.output_tokens,
-                cache_read_tokens=cache_r,
-                cache_write_tokens=cache_w,
-            )
+                    final = stream.get_final_message()
+                    for block in final.content:
+                        if block.type == "tool_use":
+                            tool_calls.append({
+                                "id":    block.id,
+                                "name":  block.name,
+                                "input": block.input,
+                            })
+
+                    cache_r, cache_w = _anthropic_cache_tokens(final.usage)
+                    yield AssistantTurn(
+                        text, tool_calls,
+                        final.usage.input_tokens,
+                        final.usage.output_tokens,
+                        cache_read_tokens=cache_r,
+                        cache_write_tokens=cache_w,
+                    )
+                return
+
+            except Exception as e:
+                # A proxy that doesn't understand cache_control rejects the
+                # request up front (400 naming the field, before any event is
+                # streamed). Retry once without breakpoints and disable caching
+                # for this endpoint so subsequent calls skip the failed attempt.
+                # Never retry after events were yielded — that would duplicate
+                # streamed text.
+                if (attempt_idx == 0 and len(attempts) > 1 and not yielded
+                        and _is_cache_control_rejection(e)):
+                    _cache_control_disabled.add(base_url)
+                    from cheetahclaws import logging_utils as _log
+                    _log.warn("prompt_cache_rejected",
+                              endpoint=base_url,
+                              error=str(e)[:200])
+                    continue
+                raise
     finally:
         # Paired with _lease_anthropic_client above; runs when the generator
         # finishes, raises, or is abandoned, so eviction can trust the count.

--- a/cheetahclaws/providers.py
+++ b/cheetahclaws/providers.py
@@ -1183,7 +1183,6 @@ def stream_anthropic(
 ) -> Generator:
     """Stream from Anthropic API. Yields TextChunk/ThinkingChunk, then AssistantTurn."""
     base_url = config.get("anthropic_endpoint") or "https://api.anthropic.com"
-    client = _lease_anthropic_client(api_key, base_url)
 
     _mt = resolve_max_tokens(config, "anthropic", model) or 8192
     # Per-call dynamic cap: shrink max_tokens when the current prompt is already
@@ -1210,6 +1209,11 @@ def stream_anthropic(
     attempts = ([_apply_anthropic_cache_control(kwargs), kwargs]
                 if use_cache else [kwargs])
 
+    # Leased only once the request is fully built: everything above can raise
+    # (malformed history in messages_to_anthropic, token estimation), and a
+    # raise between lease and try would skip the finally, wedging the lease
+    # count so eviction treats this client as in-flight forever.
+    client = _lease_anthropic_client(api_key, base_url)
     try:
         for attempt_idx, call_kwargs in enumerate(attempts):
             tool_calls = []

--- a/cheetahclaws/providers.py
+++ b/cheetahclaws/providers.py
@@ -23,6 +23,7 @@ Model string formats:
 from __future__ import annotations
 import json
 import os
+import threading
 import time
 import urllib.request
 from typing import Generator
@@ -978,6 +979,110 @@ class AssistantTurn:
         self.reasoning_content    = reasoning_content
 
 
+# ── SDK client reuse ───────────────────────────────────────────────────────
+# One client per (endpoint, key, pid) instead of one per request: keeps the
+# underlying httpx connection pool alive across the 5-50 stream() calls of a
+# single tool loop (each fresh client pays a new TCP+TLS handshake). The pid
+# is part of the key because pooled connections do not survive fork (the
+# daemon runs subprocess workers). Clients are thread-safe; the lock only
+# guards get-or-create.
+
+_CLIENT_CACHE: dict[tuple, object] = {}
+_CLIENT_LEASES: dict[tuple, int] = {}   # key → number of in-flight streams
+_CLIENT_CACHE_LOCK = threading.Lock()
+# Rotating keys/endpoints in a long-lived daemon would otherwise accumulate
+# clients (each holding an open httpx connection pool). Past this cap the
+# least-recently-used IDLE entry is closed and evicted; entries with live
+# leases are never evicted, so an in-flight stream can't have its pool
+# closed underneath it — the cap is soft while every client is busy.
+_CLIENT_CACHE_MAX = 8
+
+
+def _close_quietly(client) -> None:
+    """Best-effort close of an SDK client's underlying connection pool."""
+    close = getattr(client, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass
+
+
+def _evict_idle_clients_locked(exclude_key: tuple | None = None) -> list[object]:
+    """Evict least-recently-used idle clients until the soft cap is met.
+
+    Caller must hold ``_CLIENT_CACHE_LOCK``.  A client with a positive lease
+    is actively streaming and must remain in the cache; if every entry is
+    leased, the cap stays soft until a later release.  The just-created key
+    is excluded while it is being leased so a concurrent cache miss cannot
+    evict the client about to be returned.
+    """
+    evicted: list[object] = []
+    while len(_CLIENT_CACHE) > _CLIENT_CACHE_MAX:
+        for key in list(_CLIENT_CACHE):
+            if key != exclude_key and _CLIENT_LEASES.get(key, 0) == 0:
+                evicted.append(_CLIENT_CACHE.pop(key))
+                break
+        else:
+            break  # every cached client is in flight; keep the cap soft
+    return evicted
+
+
+def _client_cache_clear() -> None:
+    """Close and drop all cached SDK clients. Test hook + fork/shutdown
+    hygiene ONLY — it closes clients regardless of live leases, so never
+    call it while streams are in flight.
+
+    close() runs outside the lock — it can do network I/O and must not
+    serialize concurrent lease calls.
+    """
+    with _CLIENT_CACHE_LOCK:
+        clients = list(_CLIENT_CACHE.values())
+        _CLIENT_CACHE.clear()
+        _CLIENT_LEASES.clear()
+    for c in clients:
+        _close_quietly(c)
+
+
+def _lease_anthropic_client(api_key: str, base_url: str):
+    """Get-or-create a client and take a lease on it. Every lease must be
+    paired with _release_anthropic_client (stream_anthropic does this in a
+    finally), so eviction can tell idle clients from in-flight ones."""
+    import anthropic as _ant
+    key = ("anthropic", base_url, api_key, os.getpid())
+    evicted: list[object] = []
+    with _CLIENT_CACHE_LOCK:
+        client = _CLIENT_CACHE.get(key)
+        if client is not None:
+            # True LRU: a hit moves the key to the end of insertion order.
+            _CLIENT_CACHE[key] = _CLIENT_CACHE.pop(key)
+        else:
+            client = _ant.Anthropic(api_key=api_key, base_url=base_url)
+            _CLIENT_CACHE[key] = client
+            evicted = _evict_idle_clients_locked(exclude_key=key)
+        _CLIENT_LEASES[key] = _CLIENT_LEASES.get(key, 0) + 1
+    for stale in evicted:
+        _close_quietly(stale)
+    return client
+
+
+def _release_anthropic_client(api_key: str, base_url: str) -> None:
+    """Drop one lease and shrink an earlier soft-cap overflow if possible."""
+    key = ("anthropic", base_url, api_key, os.getpid())
+    with _CLIENT_CACHE_LOCK:
+        n = _CLIENT_LEASES.get(key, 0)
+        if n <= 1:
+            _CLIENT_LEASES.pop(key, None)
+        else:
+            _CLIENT_LEASES[key] = n - 1
+        # If every client was busy, a prior lease may have legitimately made
+        # the cap soft.  Releasing an idle client is the first safe chance to
+        # converge back to the configured cap without interrupting a stream.
+        evicted = _evict_idle_clients_locked()
+    for stale in evicted:
+        _close_quietly(stale)
+
+
 def stream_anthropic(
     api_key: str,
     model: str,
@@ -987,9 +1092,8 @@ def stream_anthropic(
     config: dict,
 ) -> Generator:
     """Stream from Anthropic API. Yields TextChunk/ThinkingChunk, then AssistantTurn."""
-    import anthropic as _ant
     base_url = config.get("anthropic_endpoint") or "https://api.anthropic.com"
-    client = _ant.Anthropic(api_key=api_key, base_url=base_url)
+    client = _lease_anthropic_client(api_key, base_url)
 
     _mt = resolve_max_tokens(config, "anthropic", model) or 8192
     # Per-call dynamic cap: shrink max_tokens when the current prompt is already
@@ -1015,35 +1119,40 @@ def stream_anthropic(
     tool_calls = []
     text       = ""
 
-    with client.messages.stream(**kwargs) as stream:
-        for event in stream:
-            etype = getattr(event, "type", None)
-            if etype == "content_block_delta":
-                delta = event.delta
-                dtype = getattr(delta, "type", None)
-                if dtype == "text_delta":
-                    text += delta.text
-                    yield TextChunk(delta.text)
-                elif dtype == "thinking_delta":
-                    yield ThinkingChunk(delta.thinking)
+    try:
+        with client.messages.stream(**kwargs) as stream:
+            for event in stream:
+                etype = getattr(event, "type", None)
+                if etype == "content_block_delta":
+                    delta = event.delta
+                    dtype = getattr(delta, "type", None)
+                    if dtype == "text_delta":
+                        text += delta.text
+                        yield TextChunk(delta.text)
+                    elif dtype == "thinking_delta":
+                        yield ThinkingChunk(delta.thinking)
 
-        final = stream.get_final_message()
-        for block in final.content:
-            if block.type == "tool_use":
-                tool_calls.append({
-                    "id":    block.id,
-                    "name":  block.name,
-                    "input": block.input,
-                })
+            final = stream.get_final_message()
+            for block in final.content:
+                if block.type == "tool_use":
+                    tool_calls.append({
+                        "id":    block.id,
+                        "name":  block.name,
+                        "input": block.input,
+                    })
 
-        cache_r, cache_w = _anthropic_cache_tokens(final.usage)
-        yield AssistantTurn(
-            text, tool_calls,
-            final.usage.input_tokens,
-            final.usage.output_tokens,
-            cache_read_tokens=cache_r,
-            cache_write_tokens=cache_w,
-        )
+            cache_r, cache_w = _anthropic_cache_tokens(final.usage)
+            yield AssistantTurn(
+                text, tool_calls,
+                final.usage.input_tokens,
+                final.usage.output_tokens,
+                cache_read_tokens=cache_r,
+                cache_write_tokens=cache_w,
+            )
+    finally:
+        # Paired with _lease_anthropic_client above; runs when the generator
+        # finishes, raises, or is abandoned, so eviction can trust the count.
+        _release_anthropic_client(api_key, base_url)
 
 
 def _anthropic_cache_tokens(usage) -> tuple[int, int]:

--- a/cheetahclaws/quota.py
+++ b/cheetahclaws/quota.py
@@ -169,14 +169,21 @@ def output_room(session_id: str, config: dict,
     return max(0, min(rooms))
 
 
-def record_usage(session_id: str, model: str, in_tokens: int, out_tokens: int) -> None:
+def record_usage(session_id: str, model: str, in_tokens: int, out_tokens: int,
+                 cache_read_tokens: int = 0, cache_write_tokens: int = 0) -> None:
     """
     Record token usage after a successful API call.
     Updates in-memory session counters and the on-disk daily record.
+
+    Cached tokens count toward budgets too: Anthropic reports them outside
+    input_tokens, but they are real processed input (billed at 0.1x read /
+    1.25x write) — ignoring them would let cached sessions sail past both
+    token and cost caps.
     """
     from cheetahclaws.providers import calc_cost
-    tokens = in_tokens + out_tokens
-    cost   = calc_cost(model, in_tokens, out_tokens)
+    tokens = in_tokens + out_tokens + cache_read_tokens + cache_write_tokens
+    cost   = calc_cost(model, in_tokens, out_tokens,
+                       cache_read_tokens, cache_write_tokens)
 
     with _lock:
         _sess_tokens[session_id] = _sess_tokens.get(session_id, 0) + tokens

--- a/tests/test_client_reuse.py
+++ b/tests/test_client_reuse.py
@@ -1,0 +1,225 @@
+"""SDK client-reuse coverage for the Anthropic path.
+
+stream_anthropic used to construct a fresh anthropic.Anthropic() per request,
+paying a new TCP+TLS handshake on every one of the 5-50 stream() calls a
+single tool loop issues. Clients are now leased from a module-level cache:
+
+1. Same (api_key, endpoint) reuses one client; different key or endpoint
+   gets a distinct client; a racing get-or-create creates exactly one.
+2. Streams hold a lease for their lifetime (released in a finally, even when
+   the generator is abandoned), so eviction can tell idle from in-flight.
+3. Past the soft cap the least-recently-used IDLE client is closed and
+   evicted; a leased client is never closed underneath a live stream, and
+   an all-busy overflow contracts back to the cap on release.
+4. _client_cache_clear() closes every pooled client (shutdown/fork/tests).
+
+All tests fake the anthropic SDK via sys.modules — no network, no API key.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── Fake Anthropic SDK ─────────────────────────────────────────────────────
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 2
+    cache_read_input_tokens = 0
+    cache_creation_input_tokens = 0
+
+
+class _FakeFinal:
+    content: list = []
+    usage = _FakeUsage()
+
+
+class _FakeStreamCtx:
+    def __init__(self, kwargs: dict):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_message(self):
+        return _FakeFinal()
+
+
+class _FakeMessages:
+    def stream(self, **kwargs):
+        return _FakeStreamCtx(kwargs)
+
+
+class _FakeAnthropicClient:
+    instantiations = 0
+
+    def __init__(self, api_key: str = "", base_url: str = ""):
+        type(self).instantiations += 1
+        self.api_key = api_key
+        self.base_url = base_url
+        self.closed = False
+        self.messages = _FakeMessages()
+
+    def close(self):
+        self.closed = True
+
+
+_EP = "https://api.anthropic.com"
+
+
+@pytest.fixture()
+def fake_anthropic(monkeypatch):
+    """Install a fake `anthropic` module and reset the client cache."""
+    from cheetahclaws import providers
+    _FakeAnthropicClient.instantiations = 0
+    monkeypatch.setitem(sys.modules, "anthropic",
+                        SimpleNamespace(Anthropic=_FakeAnthropicClient))
+    providers._client_cache_clear()
+    yield
+    providers._client_cache_clear()
+
+
+def _lease_release(providers, key, endpoint=_EP):
+    """Lease then immediately release — an 'idle' cache entry."""
+    c = providers._lease_anthropic_client(key, endpoint)
+    providers._release_anthropic_client(key, endpoint)
+    return c
+
+
+def _call_stream(config: dict, messages: list):
+    from cheetahclaws.providers import stream_anthropic
+    return list(stream_anthropic(
+        api_key="k1",
+        model="claude-sonnet-4-5",
+        system="SYSTEM PROMPT",
+        messages=messages,
+        tool_schemas=[],
+        config=config,
+    ))
+
+
+# ── get-or-create semantics ────────────────────────────────────────────────
+
+def test_client_reused_for_same_key_and_endpoint(fake_anthropic):
+    from cheetahclaws import providers
+    c1 = _lease_release(providers, "k1")
+    c2 = _lease_release(providers, "k1")
+    c3 = _lease_release(providers, "k2")
+    c4 = _lease_release(providers, "k1", "https://proxy.local")
+    assert c1 is c2
+    assert c1 is not c3
+    assert c1 is not c4
+    assert _FakeAnthropicClient.instantiations == 3
+
+
+def test_client_cache_thread_race_single_instantiation(fake_anthropic):
+    from cheetahclaws import providers
+
+    barrier = threading.Barrier(8)
+    results = []
+
+    def _get():
+        barrier.wait()
+        results.append(_lease_release(providers, "k1"))
+
+    threads = [threading.Thread(target=_get) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert _FakeAnthropicClient.instantiations == 1
+    assert all(r is results[0] for r in results)
+
+
+def test_stream_reuses_cached_client(fake_anthropic):
+    cfg = {"model": "claude-sonnet-4-5"}
+    _call_stream(cfg, [{"role": "user", "content": "a"}])
+    _call_stream(cfg, [{"role": "user", "content": "b"}])
+    assert _FakeAnthropicClient.instantiations == 1
+
+
+def test_stream_releases_lease_when_done(fake_anthropic):
+    from cheetahclaws import providers
+    _call_stream({"model": "claude-sonnet-4-5"},
+                 [{"role": "user", "content": "a"}])
+    with providers._CLIENT_CACHE_LOCK:
+        assert not providers._CLIENT_LEASES   # generator finally ran
+
+
+# ── lifecycle: close on clear, idle-only eviction, LRU ─────────────────────
+
+def test_client_cache_clear_closes_clients(fake_anthropic):
+    from cheetahclaws import providers
+    c1 = _lease_release(providers, "k1")
+    providers._client_cache_clear()
+    assert c1.closed
+
+
+def test_client_cache_cap_evicts_and_closes_oldest_idle(fake_anthropic):
+    from cheetahclaws import providers
+    clients = [_lease_release(providers, f"k{i}")
+               for i in range(providers._CLIENT_CACHE_MAX + 2)]
+    with providers._CLIENT_CACHE_LOCK:
+        assert len(providers._CLIENT_CACHE) <= providers._CLIENT_CACHE_MAX
+    assert clients[0].closed and clients[1].closed
+    assert not clients[-1].closed
+
+
+def test_eviction_never_closes_leased_client(fake_anthropic):
+    """A client mid-stream in another thread must never be evicted/closed
+    even when it is the oldest entry — the cap is soft while it is busy."""
+    from cheetahclaws import providers
+    busy = providers._lease_anthropic_client("busy", _EP)   # held, not released
+    for i in range(providers._CLIENT_CACHE_MAX + 3):
+        _lease_release(providers, f"k{i}")
+    assert not busy.closed
+    with providers._CLIENT_CACHE_LOCK:
+        assert ("anthropic", _EP, "busy", os.getpid()) in providers._CLIENT_CACHE
+    providers._release_anthropic_client("busy", _EP)
+
+
+def test_soft_cap_contracts_when_leased_clients_finish(fake_anthropic):
+    """An all-busy overflow must shrink after streams release their leases.
+
+    This exercises the only path where the cap is intentionally exceeded:
+    every cached client is in-flight at creation time, so none may be closed.
+    Once one finishes, the newly idle least-recently-used entry is safe to
+    evict and its connection pool must be closed.
+    """
+    from cheetahclaws import providers
+    clients = [providers._lease_anthropic_client(f"busy-{i}", _EP)
+               for i in range(providers._CLIENT_CACHE_MAX + 1)]
+    with providers._CLIENT_CACHE_LOCK:
+        assert len(providers._CLIENT_CACHE) == providers._CLIENT_CACHE_MAX + 1
+
+    for i in range(providers._CLIENT_CACHE_MAX + 1):
+        providers._release_anthropic_client(f"busy-{i}", _EP)
+
+    with providers._CLIENT_CACHE_LOCK:
+        assert len(providers._CLIENT_CACHE) == providers._CLIENT_CACHE_MAX
+        assert not providers._CLIENT_LEASES
+    assert clients[0].closed
+
+
+def test_lru_hit_protects_recently_used_from_eviction(fake_anthropic):
+    """A cache hit moves the entry to the back of the eviction order
+    (true LRU, not FIFO)."""
+    from cheetahclaws import providers
+    n = providers._CLIENT_CACHE_MAX
+    clients = [_lease_release(providers, f"k{i}") for i in range(n)]  # full
+    _lease_release(providers, "k0")          # hit → k0 becomes most recent
+    _lease_release(providers, "k_new")       # overflow → evicts k1, not k0
+    assert not clients[0].closed
+    assert clients[1].closed

--- a/tests/test_client_reuse.py
+++ b/tests/test_client_reuse.py
@@ -223,3 +223,40 @@ def test_lru_hit_protects_recently_used_from_eviction(fake_anthropic):
     _lease_release(providers, "k_new")       # overflow → evicts k1, not k0
     assert not clients[0].closed
     assert clients[1].closed
+
+
+# ── lease hygiene on failure paths ──────────────────────────────────────────
+
+def test_request_build_failure_does_not_wedge_lease(fake_anthropic):
+    """A request that fails while being BUILT (messages_to_anthropic raising
+    on a tool message with no tool_call_id) must leave no lease behind: a
+    wedged lease makes eviction treat the client as in-flight forever."""
+    from cheetahclaws import providers
+    bad = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "name": "Read", "input": {}}]},
+        {"role": "tool", "name": "Read", "content": "x"},  # no tool_call_id
+    ]
+    for _ in range(4):   # one agent turn's full retry budget
+        with pytest.raises(KeyError):
+            _call_stream({"model": "claude-sonnet-4-5"}, bad)
+    with providers._CLIENT_CACHE_LOCK:
+        assert not providers._CLIENT_LEASES
+
+
+def test_stream_failure_after_lease_releases_lease(fake_anthropic):
+    """A failure inside the streaming block itself still releases the lease
+    through the finally, keeping the lease/release pairing intact."""
+    from cheetahclaws import providers
+
+    def _boom(**kwargs):
+        raise RuntimeError("connection reset")
+
+    client = _lease_release(providers, "k1")   # seed the cached client
+    client.messages.stream = _boom
+    with pytest.raises(RuntimeError):
+        _call_stream({"model": "claude-sonnet-4-5"},
+                     [{"role": "user", "content": "a"}])
+    with providers._CLIENT_CACHE_LOCK:
+        assert not providers._CLIENT_LEASES

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,0 +1,425 @@
+"""Prompt-cache injection + SDK client-reuse coverage for the Anthropic path.
+
+Layers covered:
+1. cache_control breakpoints (last tool schema, system block, last content
+   block of the final message) present by default, absent with
+   prompt_cache=False, and never more than the API's 4-breakpoint limit
+   (including with extended thinking enabled).
+2. Copy-on-write: the shared tool-schema registry dicts and the neutral
+   session messages are never mutated by annotation.
+3. Legacy shape: prompt_cache=False produces exactly today's kwargs
+   (plain-string system, zero cache_control keys anywhere).
+4. Proxy fallback: a 400 naming cache_control triggers one retry without
+   breakpoints and disables caching for that endpoint; transient errors
+   that merely mention the field do not.
+5. Quota projection reserves the 1.25x cache-write premium exactly when
+   the next request will actually carry cache_control.
+6. Cross-provider isolation: the OpenAI-compat request payload never
+   contains cache_control.
+7. calc_cost prices cache tokens at 0.1x read / 1.25x write.
+
+(SDK client reuse is covered separately in tests/test_client_reuse.py.)
+All tests fake the SDKs via sys.modules — no network, no API key.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── Fake Anthropic SDK ─────────────────────────────────────────────────────
+
+_CAPTURED: dict = {}
+
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 2
+    cache_read_input_tokens = 0
+    cache_creation_input_tokens = 0
+
+
+class _FakeFinal:
+    content: list = []
+    usage = _FakeUsage()
+
+
+class _FakeStreamCtx:
+    def __init__(self, kwargs: dict):
+        _CAPTURED.clear()
+        _CAPTURED.update(kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_message(self):
+        return _FakeFinal()
+
+
+class _FakeMessages:
+    def stream(self, **kwargs):
+        return _FakeStreamCtx(kwargs)
+
+
+class _FakeAnthropicClient:
+    instantiations = 0
+
+    def __init__(self, api_key: str = "", base_url: str = ""):
+        type(self).instantiations += 1
+        self.api_key = api_key
+        self.base_url = base_url
+        self.closed = False
+        self.messages = _FakeMessages()
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture()
+def fake_anthropic(monkeypatch):
+    """Install a fake `anthropic` module and reset provider-level caches."""
+    from cheetahclaws import providers
+    _CAPTURED.clear()
+    _FakeAnthropicClient.instantiations = 0
+    fake_mod = SimpleNamespace(Anthropic=_FakeAnthropicClient)
+    monkeypatch.setitem(sys.modules, "anthropic", fake_mod)
+    providers._client_cache_clear()
+    providers._cache_control_disabled.clear()
+    yield _CAPTURED
+    providers._client_cache_clear()
+    providers._cache_control_disabled.clear()
+
+
+def _call_stream(config: dict, messages: list, tools: list, system="SYSTEM PROMPT"):
+    from cheetahclaws.providers import stream_anthropic
+    return list(stream_anthropic(
+        api_key="k1",
+        model="claude-sonnet-4-5",
+        system=system,
+        messages=messages,
+        tool_schemas=tools,
+        config=config,
+    ))
+
+
+def _make_tools():
+    return [
+        {"name": "Read", "description": "read", "input_schema": {"type": "object"}},
+        {"name": "Bash", "description": "run", "input_schema": {"type": "object"}},
+    ]
+
+
+def _make_msgs():
+    return [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "ok", "tool_calls": [
+            {"id": "t1", "name": "Read", "input": {"file_path": "/x"}},
+        ]},
+        {"role": "tool", "tool_call_id": "t1", "name": "Read", "content": "data"},
+    ]
+
+
+def _count_cache_controls(kwargs: dict) -> int:
+    n = 0
+    for t in kwargs.get("tools", []) or []:
+        n += "cache_control" in t
+    system = kwargs.get("system")
+    if isinstance(system, list):
+        n += sum("cache_control" in b for b in system if isinstance(b, dict))
+    for m in kwargs.get("messages", []) or []:
+        c = m.get("content")
+        if isinstance(c, list):
+            n += sum("cache_control" in b for b in c if isinstance(b, dict))
+    return n
+
+
+# ── 1: breakpoint placement ────────────────────────────────────────────────
+
+def test_cache_breakpoints_present_by_default(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5"}, _make_msgs(), _make_tools())
+    kw = fake_anthropic
+
+    assert isinstance(kw["system"], list)
+    assert kw["system"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert kw["system"][-1]["text"] == "SYSTEM PROMPT"
+
+    assert "cache_control" not in kw["tools"][0]
+    assert kw["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+    # Final converted message is the collected tool_result block list.
+    last_content = kw["messages"][-1]["content"]
+    assert isinstance(last_content, list)
+    assert last_content[-1]["cache_control"] == {"type": "ephemeral"}
+    assert last_content[-1]["type"] == "tool_result"
+
+
+def test_exactly_three_breakpoints_within_api_limit(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5"}, _make_msgs(), _make_tools())
+    assert _count_cache_controls(fake_anthropic) == 3
+
+
+def test_thinking_enabled_keeps_breakpoint_count(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5", "thinking": True},
+                 _make_msgs(), _make_tools())
+    assert fake_anthropic["thinking"]["type"] == "enabled"
+    n = _count_cache_controls(fake_anthropic)
+    assert n == 3
+    assert n <= 4
+
+
+def test_string_user_final_message_wrapped_in_text_block(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5"},
+                 [{"role": "user", "content": "plain"}], _make_tools())
+    last = fake_anthropic["messages"][-1]["content"]
+    assert last == [{"type": "text", "text": "plain",
+                     "cache_control": {"type": "ephemeral"}}]
+
+
+def test_no_tools_no_system_still_safe(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5"},
+                 [{"role": "user", "content": "q"}], [], system="")
+    kw = fake_anthropic
+    assert kw["tools"] == []
+    assert kw["system"] == ""          # empty system left untouched
+    assert _count_cache_controls(kw) == 1   # only the message breakpoint
+
+
+# ── 2: copy-on-write ───────────────────────────────────────────────────────
+
+def test_registry_tool_schemas_not_mutated(fake_anthropic):
+    tools = _make_tools()
+    snapshot = json.dumps(tools, sort_keys=True)
+    _call_stream({"model": "claude-sonnet-4-5"}, _make_msgs(), tools)
+    assert json.dumps(tools, sort_keys=True) == snapshot
+
+
+def test_neutral_messages_not_mutated(fake_anthropic):
+    msgs = _make_msgs()
+    snapshot = json.dumps(msgs, sort_keys=True)
+    _call_stream({"model": "claude-sonnet-4-5"}, msgs, _make_tools())
+    assert json.dumps(msgs, sort_keys=True) == snapshot
+    assert "cache_control" not in json.dumps(msgs)
+
+
+# ── 3: legacy shape with the flag off ──────────────────────────────────────
+
+def test_prompt_cache_false_restores_legacy_shape(fake_anthropic):
+    _call_stream({"model": "claude-sonnet-4-5", "prompt_cache": False},
+                 _make_msgs(), _make_tools())
+    kw = fake_anthropic
+    assert kw["system"] == "SYSTEM PROMPT"
+    assert "cache_control" not in json.dumps(kw["tools"])
+    assert "cache_control" not in json.dumps(kw["messages"])
+
+
+# ── 4: proxy 400 fallback ──────────────────────────────────────────────────
+
+def test_cache_control_rejection_retries_without_and_disables(monkeypatch):
+    from cheetahclaws import providers
+    providers._client_cache_clear()
+    providers._cache_control_disabled.clear()
+
+    calls: list[dict] = []
+
+    class _RejectingStreamCtx(_FakeStreamCtx):
+        def __init__(self, kwargs):
+            calls.append(kwargs)
+            if "cache_control" in json.dumps(kwargs):
+                raise RuntimeError(
+                    "400 invalid_request_error: unexpected field cache_control")
+            super().__init__(kwargs)
+
+    class _RejectingMessages:
+        def stream(self, **kwargs):
+            return _RejectingStreamCtx(kwargs)
+
+    class _RejectingClient(_FakeAnthropicClient):
+        def __init__(self, api_key="", base_url=""):
+            super().__init__(api_key=api_key, base_url=base_url)
+            self.messages = _RejectingMessages()
+
+    fake_mod = SimpleNamespace(Anthropic=_RejectingClient)
+    monkeypatch.setitem(sys.modules, "anthropic", fake_mod)
+
+    cfg = {"model": "claude-sonnet-4-5",
+           "anthropic_endpoint": "https://proxy.local"}
+    events = _call_stream(cfg, [{"role": "user", "content": "q"}], _make_tools())
+
+    # First attempt carried breakpoints and was rejected; retry succeeded bare.
+    assert len(calls) == 2
+    assert "cache_control" in json.dumps(calls[0])
+    assert "cache_control" not in json.dumps(calls[1])
+    assert events  # AssistantTurn still produced
+
+    # Endpoint is disabled for the rest of the process: next call goes bare.
+    calls.clear()
+    _call_stream(cfg, [{"role": "user", "content": "q2"}], _make_tools())
+    assert len(calls) == 1
+    assert "cache_control" not in json.dumps(calls[0])
+
+    providers._client_cache_clear()
+    providers._cache_control_disabled.clear()
+
+
+# ── rejection-detection narrowing ──────────────────────────────────────────
+
+def test_rejection_detector_requires_schema_signal():
+    from cheetahclaws.providers import _is_cache_control_rejection
+
+    assert _is_cache_control_rejection(
+        RuntimeError("400 invalid_request_error: unexpected field cache_control"))
+    err = RuntimeError("cache_control not supported")
+    err.status_code = 400
+    assert _is_cache_control_rejection(err)
+
+    # Transient errors that merely mention the field must NOT disable caching.
+    assert not _is_cache_control_rejection(
+        RuntimeError("connection reset while sending cache_control block"))
+    assert not _is_cache_control_rejection(RuntimeError("400 bad request"))
+
+
+def test_transient_error_mentioning_cache_control_does_not_disable(monkeypatch):
+    from cheetahclaws import providers
+    providers._client_cache_clear()
+    providers._cache_control_disabled.clear()
+
+    calls: list[dict] = []
+
+    class _FlakyStreamCtx(_FakeStreamCtx):
+        def __init__(self, kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("connection reset while sending cache_control block")
+
+    class _FlakyMessages:
+        def stream(self, **kwargs):
+            return _FlakyStreamCtx(kwargs)
+
+    class _FlakyClient(_FakeAnthropicClient):
+        def __init__(self, api_key="", base_url=""):
+            super().__init__(api_key=api_key, base_url=base_url)
+            self.messages = _FlakyMessages()
+
+    monkeypatch.setitem(sys.modules, "anthropic",
+                        SimpleNamespace(Anthropic=_FlakyClient))
+
+    with pytest.raises(RuntimeError):
+        _call_stream({"model": "claude-sonnet-4-5"},
+                     [{"role": "user", "content": "q"}], _make_tools())
+    # No blind fallback retry, and the endpoint stays cache-enabled.
+    assert len(calls) == 1
+    assert not providers._cache_control_disabled
+
+    providers._client_cache_clear()
+
+
+# ── quota projection reserves the cache-write premium ──────────────────────
+
+def test_quota_projection_reserves_cache_write_premium(monkeypatch, tmp_path):
+    """A cost budget between the raw input estimate and its 1.25x cache-write
+    ceiling must pause BEFORE the call when prompt caching is on, and proceed
+    when it is off — the reviewer scenario of a full-miss overshooting an
+    approved budget."""
+    from cheetahclaws import tools as _tools_init  # noqa: F401 - register tools
+    from cheetahclaws import quota
+    from cheetahclaws.agent import AgentState, run, QuotaPause
+    from cheetahclaws.providers import AssistantTurn, calc_cost
+
+    monkeypatch.setattr(quota, "_quota_dir", lambda: tmp_path)
+
+    def fake_stream(**_kwargs):
+        yield AssistantTurn("done", [], 0, 0)
+
+    monkeypatch.setattr("cheetahclaws.agent.stream", fake_stream)
+
+    model = "claude-sonnet-4-6"
+    prompt = "x" * 28_000          # ≈11k estimated input tokens
+    from cheetahclaws.compaction import estimate_tokens
+    proj = (estimate_tokens([{"role": "user", "content": prompt}])
+            + estimate_tokens([{"role": "system", "content": "sys"}]))
+    raw_cost = calc_cost(model, proj, 0)
+    budget = raw_cost * 1.1        # raw fits, 1.25x-reserved does not
+
+    def _run(cfg_extra, sid):
+        quota._sess_tokens.pop(sid, None)
+        quota._sess_cost.pop(sid, None)
+        state = AgentState()
+        cfg = {"model": model, "permission_mode": "accept-all",
+               "_session_id": sid, "disabled_tools": ["Agent"],
+               "session_cost_budget": budget, **cfg_extra}
+        return list(run(prompt, state, cfg, "sys"))
+
+    events_on = _run({}, "quota_cache_on")
+    assert any(isinstance(e, QuotaPause) for e in events_on)
+
+    events_off = _run({"prompt_cache": False}, "quota_cache_off")
+    assert not any(isinstance(e, QuotaPause) for e in events_off)
+
+    # Reviewer scenario: after a proxy rejection disabled the endpoint, the
+    # real request goes out raw — the projection must NOT reserve the 1.25x
+    # premium anymore, or a budget the raw request fits within would wrongly
+    # pause. is_prompt_cache_active() keeps both sides consistent.
+    from cheetahclaws import providers
+    providers._cache_control_disabled.add("https://api.anthropic.com")
+    try:
+        events_disabled = _run({}, "quota_cache_disabled_ep")
+        assert not any(isinstance(e, QuotaPause) for e in events_disabled)
+    finally:
+        providers._cache_control_disabled.clear()
+
+
+# ── 6: cross-provider isolation ────────────────────────────────────────────
+
+def test_openai_compat_payload_never_contains_cache_control(monkeypatch):
+    captured: dict = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return iter(())
+
+    class _FakeOpenAIClient:
+        def __init__(self, api_key="", base_url=""):
+            self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    fake_mod = SimpleNamespace(OpenAI=_FakeOpenAIClient)
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+
+    from cheetahclaws.providers import stream_openai_compat
+    list(stream_openai_compat(
+        api_key="k", base_url="https://api.openai.com/v1",
+        model="gpt-4o", system="SYS",
+        messages=_make_msgs(), tool_schemas=_make_tools(),
+        config={"model": "gpt-4o", "prompt_cache": True},
+    ))
+    assert captured
+    assert "cache_control" not in json.dumps(captured, default=str)
+
+
+# ── 7: cache-aware pricing ─────────────────────────────────────────────────
+
+def test_calc_cost_prices_cache_tokens():
+    from cheetahclaws.providers import calc_cost, COSTS, bare_model
+    model = "claude-sonnet-4-6"
+    ic, oc = COSTS.get(bare_model(model), (0.0, 0.0))
+    assert ic > 0, "test model must have a price entry"
+
+    base = calc_cost(model, 1000, 0)
+    with_cache = calc_cost(model, 1000, 0,
+                           cache_read_tok=10_000, cache_write_tok=1000)
+    expected_extra = (10_000 * 0.1 + 1000 * 1.25) * ic / 1_000_000
+    assert with_cache == pytest.approx(base + expected_extra)
+
+
+def test_calc_cost_backward_compatible():
+    from cheetahclaws.providers import calc_cost
+    assert calc_cost("claude-sonnet-4-5", 100, 50) == calc_cost(
+        "claude-sonnet-4-5", 100, 50, 0, 0)


### PR DESCRIPTION
## Summary

Activates the Anthropic prompt-caching support that CheetahClaws already meters but never triggers, and reuses SDK clients across requests. Two focused commits:

1. **`perf(providers): reuse SDK clients across requests via leased cache`** — `stream_anthropic` constructed a fresh `anthropic.Anthropic()` per call, paying a new TCP+TLS handshake for each of the 5–50 sequential `stream()` calls a single agent tool loop issues. Clients are now leased from a module-level cache (keyed `provider, base_url, api_key, pid`) with lease-aware LRU eviction: a client mid-stream is never closed underneath a live request.

2. **`feat(providers): activate Anthropic prompt caching with cache-aware costs`** — adds three ephemeral `cache_control` breakpoints (last tool schema, system block, last content block of the final message — 3 of the API's max 4), a `prompt_cache` config flag (default on), a one-shot fallback for proxies that reject the field, and cache-aware pricing in `calc_cost` / quota / `/cost`.

## Motivation

The metering half of this feature already exists in the tree — `_anthropic_cache_tokens()` (`providers.py`), `AgentState.total_cache_read_tokens/total_cache_write_tokens`, checkpoint token snapshots, and `tests/test_cache_tokens.py` — but with no `cache_control` in the request kwargs those counters are structurally zero on Anthropic. Every iteration of the agent tool loop re-sends an identical prefix (tools → system → history) at full input price.

This also serves the paper's §5.1 agenda directly ("From Model Scaling to System Scaling", arXiv:2605.26112): token cost, context efficiency, and latency become *live* process metrics on the harness's dominant workload instead of a permanently-zero column. It also makes cost comparisons against harnesses that cache unconditionally (e.g. Claude Code) apples-to-apples.

## Economics (stated honestly)

- Cache reads bill at **0.1×** the input rate, writes at **1.25×** (5-min TTL). Break-even hit rate ≈ 22%.
- Within one tool loop the prefix is byte-stable, so a 10-iteration turn cuts input cost roughly **70–80%**.
- Worst case (single-shot turns, >5-min gaps, or churned prefixes) is bounded at **+25%** on the marked spans. The quota projection reserves this premium up front so a permitted call cannot overshoot a cost budget.
- Prompts below the model-dependent minimum cacheable prefix (1024–4096 tokens) silently no-op — not a bug.
- Anthropic reports cached tokens **outside** `usage.input_tokens`, so `calc_cost`/quota now price them explicitly; omitting that would under-report real spend once caching activates.

## Safety / compatibility

- `prompt_cache: true` in `DEFAULTS` is the escape hatch for custom `anthropic_endpoint` proxies. A schema-level rejection (400 naming the field, detected before any event is streamed) retries once without breakpoints and disables caching for that endpoint for the rest of the process; transient errors that merely mention the field re-raise untouched.
- Annotation is strictly copy-on-write: registry tool-schema dicts and the neutral session history are never mutated; OpenAI-compat/litellm/Ollama payloads never contain `cache_control` (asserted in tests).
- With the flag off, request kwargs are byte-identical to today's (asserted in tests).
- No new dependencies; `anthropic>=0.40.0` already in `pyproject.toml`.

## Verification

- 32 new tests across `tests/test_client_reuse.py` and `tests/test_prompt_cache.py` (fake SDKs via `sys.modules`, no network/key needed in CI): breakpoint placement for both final-message shapes, exact breakpoint count ≤ 4 (including with extended thinking), flag-off legacy shape, non-mutation, rejection fallback + endpoint disable, transient-error passthrough, budget premium reservation, lease/LRU/idle-only eviction, and cache-aware pricing.
- Full suite: 2440 passed locally (Python 3.12; the two pre-existing macOS-specific failures — `test_rlimit_as_kills_runaway_alloc`, `test_nested_SKILL_uppercase` — fail identically on `main`).
- Live evidence: with a real key, the existing `api_call_done` structured log shows `cache_read_tokens > 0` from the second iteration of any multi-tool turn, and `/cost` now displays the cache lines.