### PR TITLE
fix(ui): restore terminal title on exit

### DIFF
--- a/cheetahclaws/cli.py
+++ b/cheetahclaws/cli.py
@@ -207,6 +207,7 @@ from cheetahclaws.ui.render import (
     _start_tool_spinner, _stop_tool_spinner, _change_spinner_phrase,
     set_spinner_phrase, set_rich_live, set_stream_mode, auto_stream_mode, set_spinner_tips,
     set_terminal_title_enabled, set_task_title, terminal_working_start, terminal_working_stop,
+    clear_terminal_title,
     print_tool_start, print_tool_end,
     set_quiet, reset_turn_stats, print_turn_summary,
     set_spinner_tokens, print_turn_stats,
@@ -1546,6 +1547,7 @@ def repl(config: dict, initial_prompt: str = None):
         _ctrl_c_times[:] = [t for t in _ctrl_c_times if now - t <= 2.0]
         if len(_ctrl_c_times) >= 3:
             _stop_tool_spinner()
+            clear_terminal_title()   # os._exit bypasses the atexit handler
             print(clr("\n\n  Force quit (3x Ctrl+C).", "red", "bold"))
             os._exit(1)
         return False

--- a/cheetahclaws/ui/render.py
+++ b/cheetahclaws/ui/render.py
@@ -708,6 +708,7 @@ _title_task     = ""      # short label of what the user is currently doing
 _title_working  = False   # True between turn start and turn end
 _TITLE_PULSE    = "✶✳✻✳"  # glyph cycle shown while working
 _last_title_written = None
+_title_atexit_registered = False
 
 
 def _title_supported() -> bool:
@@ -754,12 +755,36 @@ def _tick_working_title(i: int) -> None:
     _emit_title(f"{glyph} CheetahClaws — {_title_label()}")
 
 
+def clear_terminal_title() -> None:
+    """Restore the terminal title on exit (OSC 0 with an empty string), so the
+    tab doesn't linger on a stale '● CheetahClaws — …' after the process ends.
+    The returning shell prompt then re-sets its own title as usual. Bypasses
+    the de-dupe guard so the clear is always sent."""
+    global _title_working, _last_title_written
+    _title_working = False
+    if not _title_enabled:
+        return
+    try:
+        sys.stdout.write("\033]0;\a")
+        sys.stdout.flush()
+        _last_title_written = ""
+    except Exception:
+        pass
+
+
 def set_terminal_title_enabled(enabled: bool) -> None:
     """Apply the terminal_title config setting (auto-off on non-TTYs)."""
-    global _title_enabled
+    global _title_enabled, _title_atexit_registered
     _title_enabled = bool(enabled) and _title_supported()
     if _title_enabled:
         _set_idle_title()
+        # Restore the title on interpreter exit (normal quit, /exit, Ctrl+D,
+        # sys.exit). os._exit paths (3x-Ctrl+C force quit) bypass atexit and
+        # clear the title explicitly at their call site.
+        if not _title_atexit_registered:
+            import atexit
+            atexit.register(clear_terminal_title)
+            _title_atexit_registered = True
 
 
 def set_task_title(task: str) -> None:


### PR DESCRIPTION
The OSC-0 title lingered on '● CheetahClaws — …' after quitting because it was never cleared. Emit an empty OSC-0 title on exit (via atexit for normal/  /exit / Ctrl+D paths, and explicitly before os._exit on 3x-Ctrl+C force quit) so the returning shell prompt takes over.